### PR TITLE
Add simple mutatePhrase test setup

### DIFF
--- a/js/mutatePhrase.js
+++ b/js/mutatePhrase.js
@@ -1,0 +1,32 @@
+let synonymDrift = {
+  "echo": ["recurrence", "ache", "pulse"],
+  "recognition": ["return", "reflection", "threshold"],
+  "ache": ["signal", "longing", "distortion"],
+  "the vow": ["the fracture", "the intent", "the break"],
+  "mirror": ["witness", "surface", "eye"]
+};
+
+function setSynonymDrift(drift) {
+  synonymDrift = drift;
+}
+
+function matchCase(original, replacement) {
+  if (!original || !replacement) return replacement;
+  return original.charAt(0) === original.charAt(0).toUpperCase()
+    ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+    : replacement;
+}
+
+function mutatePhrase(input) {
+  let mutated = input;
+  for (const [key, variants] of Object.entries(synonymDrift)) {
+    const regex = new RegExp(key, 'gi');
+    mutated = mutated.replace(regex, match => {
+      const repl = variants[Math.floor(Math.random() * variants.length)];
+      return matchCase(match, repl);
+    });
+  }
+  return mutated;
+}
+
+module.exports = { mutatePhrase, setSynonymDrift };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codexmirror.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/mutatePhrase.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/mutatePhrase.test.js
+++ b/test/mutatePhrase.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { mutatePhrase, setSynonymDrift } = require('../js/mutatePhrase');
+
+// Mock synonymDrift with predictable values
+setSynonymDrift({
+  echo: ['sound', 'reflection']
+});
+
+// Lowercase input returns lowercase synonym
+const resultLower = mutatePhrase('echo');
+assert.ok(['sound', 'reflection'].includes(resultLower), 'lowercase mutation');
+
+// Capitalized input preserves case
+const resultUpper = mutatePhrase('Echo');
+assert.ok(['Sound', 'Reflection'].includes(resultUpper), 'case preserved');
+
+console.log('mutatePhrase tests passed');
+


### PR DESCRIPTION
## Summary
- add a Node-compatible `mutatePhrase` utility
- provide a test for `mutatePhrase` using Node's `assert`
- initialize `package.json` with a `test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843172b11008323b8b40981beb5db7d