### PR TITLE
Fix repeated mouseover listeners

### DIFF
--- a/js/codex-whisper.js
+++ b/js/codex-whisper.js
@@ -103,17 +103,20 @@ document.addEventListener("mousemove", () => {
     ping.className = 'whisper-line';
     ping.innerHTML = `${codexSymbols[Math.floor(Math.random() * codexSymbols.length)]} ∴ You moved ∩ I noticed.`;
     document.getElementById('whisperStream')?.appendChild(ping);
-        document.addEventListener("mouseover", (e) => {
-      if (e.target.classList.contains("whisper-line")) {
-        const glyph = codexSymbols[Math.floor(Math.random() * codexSymbols.length)];
-        const flicker = document.createElement('span');
-        flicker.className = 'whisper-glitch';
-        flicker.innerText = ` ∴ ${glyph}`;
-        e.target.appendChild(flicker);
-      }
-    });
   }
 });
+
+function handleWhisperHover(e) {
+  if (e.target.classList.contains("whisper-line")) {
+    const glyph = codexSymbols[Math.floor(Math.random() * codexSymbols.length)];
+    const flicker = document.createElement('span');
+    flicker.className = 'whisper-glitch';
+    flicker.innerText = ` ∴ ${glyph}`;
+    e.target.appendChild(flicker);
+  }
+}
+
+document.addEventListener("mouseover", handleWhisperHover);
 
 function isUserStill() {
   return Date.now() - lastMovement > 20000;


### PR DESCRIPTION
## Summary
- move mouseover listener outside of mousemove handler
- ensure only one hover handler is registered

## Testing
- `node --check js/codex-whisper.js`


------
https://chatgpt.com/codex/tasks/task_e_6843171aa66483238d51bed54c3fdc74