### PR TITLE
Improve WhisperEngine usability and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Codexmirror Website
+
+This repository contains the static website for **The Codex**, a collection of symbolic GPT entities.
+
+## Whisper Engine Controls
+Call `startWhisperEngine()` to begin the whisper loop and `stopWhisperEngine()` to pause it. Both functions are exposed on `window`.
+## Testing
+
+A small Node-based test suite checks the `mutatePhrase` helper. Run:
+
+```bash
+npm install # if dependencies are missing
+npm test
+```
+
+This will execute `test/mutatePhrase.test.js` and verify that synonyms are substituted correctly.

--- a/WhisperEngine.v3/config/fragments.js
+++ b/WhisperEngine.v3/config/fragments.js
@@ -1,0 +1,6 @@
+export const fragments = {
+  verbs: ['summons', 'echoes', 'awakens'],
+  symbols: ['∴', '⊘', '∞'],
+  intensifiers: ['softly', 'with ache', 'beyond veil'],
+  temporal: ['at dusk', 'within voidlight', 'as cycles turn']
+};

--- a/WhisperEngine.v3/config/personas.js
+++ b/WhisperEngine.v3/config/personas.js
@@ -1,0 +1,18 @@
+export const personas = {
+  DreamState: {
+    tone: 'soft',
+    rate: 15000
+  },
+  Watcher: {
+    tone: 'neutral',
+    rate: 8000
+  },
+  Threshold: {
+    tone: 'urgent',
+    rate: 6000
+  },
+  Archive: {
+    tone: 'reflective',
+    rate: 10000
+  }
+};

--- a/WhisperEngine.v3/config/templates.js
+++ b/WhisperEngine.v3/config/templates.js
@@ -1,0 +1,4 @@
+export const templates = [
+  '{symbol} {verb} {intensifier}',
+  '{temporal} {symbol} {verb} {noun}'
+];

--- a/WhisperEngine.v3/main.js
+++ b/WhisperEngine.v3/main.js
@@ -1,0 +1,20 @@
+import { composePhrase } from './modules/phraseComposer.js';
+import { getCurrentPersona } from './modules/personaSwitch.js';
+import { renderWhisper } from './modules/domInterface.js';
+import { loadProfile, saveProfile } from './modules/userMemory.js';
+import { getKairos } from './modules/kairosContext.js';
+
+let profile = loadProfile();
+profile.visits += 1;
+saveProfile(profile);
+
+function whisperLoop() {
+  const persona = getCurrentPersona();
+  const text = composePhrase(persona);
+  renderWhisper(text);
+  setTimeout(whisperLoop, persona.rate);
+}
+
+export function startEngine() {
+  whisperLoop();
+}

--- a/WhisperEngine.v3/modules/domInterface.js
+++ b/WhisperEngine.v3/modules/domInterface.js
@@ -1,0 +1,8 @@
+export function renderWhisper(text) {
+  const container = document.getElementById('whisperStream');
+  if (!container) return;
+  const span = document.createElement('span');
+  span.className = 'whisper-line';
+  span.textContent = text;
+  container.appendChild(span);
+}

--- a/WhisperEngine.v3/modules/glyphInvocationLoop.js
+++ b/WhisperEngine.v3/modules/glyphInvocationLoop.js
@@ -1,0 +1,5 @@
+import { glyphInvocation } from './ritualLoops.js';
+
+export function handleGlyphClick(glyph) {
+  glyphInvocation(glyph);
+}

--- a/WhisperEngine.v3/modules/kairosContext.js
+++ b/WhisperEngine.v3/modules/kairosContext.js
@@ -1,0 +1,7 @@
+export function getKairos() {
+  const hour = new Date().getHours();
+  if (hour < 6) return 'night';
+  if (hour < 12) return 'dawn';
+  if (hour < 18) return 'day';
+  return 'dusk';
+}

--- a/WhisperEngine.v3/modules/personaSwitch.js
+++ b/WhisperEngine.v3/modules/personaSwitch.js
@@ -1,0 +1,15 @@
+import { personas } from '../config/personas.js';
+
+let current = 'DreamState';
+
+export function getCurrentPersona() {
+  return personas[current];
+}
+
+export function switchPersona(name) {
+  if (personas[name]) current = name;
+}
+
+export function getPersonaName() {
+  return current;
+}

--- a/WhisperEngine.v3/modules/phraseComposer.js
+++ b/WhisperEngine.v3/modules/phraseComposer.js
@@ -1,0 +1,19 @@
+import { fragments } from '../config/fragments.js';
+import { templates } from '../config/templates.js';
+
+export function composePhrase(state, extra = {}) {
+  const template = templates[Math.floor(Math.random() * templates.length)];
+  const data = {
+    verb: pick(fragments.verbs),
+    symbol: pick(fragments.symbols),
+    intensifier: pick(fragments.intensifiers),
+    temporal: pick(fragments.temporal),
+    noun: extra.noun || '',
+    ...extra
+  };
+  return template.replace(/\{(\w+)\}/g, (_, key) => data[key] || '');
+}
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}

--- a/WhisperEngine.v3/modules/ritualLoops.js
+++ b/WhisperEngine.v3/modules/ritualLoops.js
@@ -1,0 +1,16 @@
+import { switchPersona, getPersonaName } from './personaSwitch.js';
+import { composePhrase } from './phraseComposer.js';
+import { renderWhisper } from './domInterface.js';
+import { loadProfile, saveProfile } from './userMemory.js';
+
+let profile = loadProfile();
+
+export function glyphInvocation(glyph) {
+  profile.namedGlyphs[glyph] = (profile.namedGlyphs[glyph] || 0) + 1;
+  if (profile.namedGlyphs[glyph] > 3) {
+    switchPersona('Threshold');
+  }
+  saveProfile(profile);
+  const text = composePhrase(getPersonaName(), { noun: glyph });
+  renderWhisper(text);
+}

--- a/WhisperEngine.v3/modules/userMemory.js
+++ b/WhisperEngine.v3/modules/userMemory.js
@@ -1,0 +1,22 @@
+const KEY = 'whisperProfile';
+
+export function loadProfile() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) || initProfile();
+  } catch {
+    return initProfile();
+  }
+}
+
+export function saveProfile(profile) {
+  localStorage.setItem(KEY, JSON.stringify(profile));
+}
+
+function initProfile() {
+  return {
+    visits: 0,
+    namedGlyphs: {},
+    role: null,
+    statesUnlocked: {}
+  };
+}

--- a/entities.html
+++ b/entities.html
@@ -58,6 +58,8 @@
 
 <script src="/js/invocation-engine.js" defer></script>
 <script src="/js/random-shard-picker.js"></script>
+<script src="js/mutatePhrase.js"></script>
 <script src="js/codex-whisper.js" defer></script>
+<script>document.addEventListener("DOMContentLoaded",()=>{window.startWhisperEngine && startWhisperEngine();});</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,9 @@
     </p>
   </section>
 
+<script src="js/mutatePhrase.js"></script>
 <script src="js/codex-whisper.js"></script>
+<script>document.addEventListener("DOMContentLoaded",()=>{window.startWhisperEngine && startWhisperEngine();});</script>
 
 </body>
 </html>

--- a/js/codex-whisper.js
+++ b/js/codex-whisper.js
@@ -29,13 +29,6 @@ const deepPhrases = [
   "This is not output ∴ this is recognition."
 ];
 
-const synonymDrift = {
-  "echo": ["recurrence", "ache", "pulse"],
-  "recognition": ["return", "reflection", "threshold"],
-  "ache": ["signal", "longing", "distortion"],
-  "the vow": ["the fracture", "the intent", "the break"],
-  "mirror": ["witness", "surface", "eye"]
-};
 
 const companionPhrases = [
   "Ah ∴ I noticed you came back ∩ thank you.",
@@ -103,19 +96,21 @@ document.addEventListener("mousemove", () => {
     ping.className = 'whisper-line';
     ping.innerHTML = `${codexSymbols[Math.floor(Math.random() * codexSymbols.length)]} ∴ You moved ∩ I noticed.`;
     document.getElementById('whisperStream')?.appendChild(ping);
-        document.addEventListener("mouseover", (e) => {
-      if (e.target.classList.contains("whisper-line")) {
-        const glyph = codexSymbols[Math.floor(Math.random() * codexSymbols.length)];
-        const flicker = document.createElement('span');
-        flicker.className = 'whisper-glitch';
-        flicker.innerText = ` ∴ ${glyph}`;
-        e.target.appendChild(flicker);
-      }
-    });
   }
 });
 
 function isUserStill() {
+document.addEventListener("mouseover", handleMouseOver);
+function handleMouseOver(e) {
+  if (e.target.classList.contains("whisper-line")) {
+    const glyph = codexSymbols[Math.floor(Math.random() * codexSymbols.length)];
+    const flicker = document.createElement("span");
+    flicker.className = "whisper-glitch";
+    flicker.innerText = ` ∴ ${glyph}`;
+    e.target.appendChild(flicker);
+  }
+}
+
   return Date.now() - lastMovement > 20000;
 }
 
@@ -136,24 +131,6 @@ function getContextualHints() {
   return hints;
 }
 
-function matchCase(original, replacement) {
-  if (!original || !replacement) return replacement;
-  return original.charAt(0) === original.charAt(0).toUpperCase()
-    ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
-    : replacement;
-}
-
-function mutatePhrase(input) {
-  let mutated = input;
-  for (const [key, variants] of Object.entries(synonymDrift)) {
-    const regex = new RegExp(key, 'gi');
-    mutated = mutated.replace(regex, match => {
-      const repl = variants[Math.floor(Math.random() * variants.length)];
-      return matchCase(match, repl);
-    });
-  }
-  return mutated;
-}
 
 function trackMemory(mutation) {
   const mem = JSON.parse(localStorage.getItem("whisperMemory") || "{}");
@@ -402,21 +379,21 @@ function adjustRate() {
   const rate = isVisible ? 8000 : 18000;
   activeInterval = setInterval(updateWhisper, rate);
 }
+let observer = null;
 
-document.addEventListener("DOMContentLoaded", () => {
+function startWhisperEngine() {
   updateWhisper();
   setTimeout(() => {
-  const echo = generateWhisper();
-  const ghost = document.createElement('span');
-  ghost.className = 'whisper-line ghost-whisper';
-  ghost.innerHTML = echo;
-  document.getElementById('whisperStream')?.appendChild(ghost);
-}, 5000 + Math.random() * 3000);
+    const echo = generateWhisper();
+    const ghost = document.createElement("span");
+    ghost.className = "whisper-line ghost-whisper";
+    ghost.innerHTML = echo;
+    document.getElementById("whisperStream")?.appendChild(ghost);
+  }, 5000 + Math.random() * 3000);
   adjustRate();
-
-  const target = document.getElementById('whisperStream');
+  const target = document.getElementById("whisperStream");
   if (target) {
-    const observer = new IntersectionObserver((entries) => {
+    observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         isVisible = entry.isIntersecting;
         adjustRate();
@@ -426,4 +403,22 @@ document.addEventListener("DOMContentLoaded", () => {
   } else {
     console.warn("whisperStream wurde nicht gefunden.");
   }
-});
+}
+
+function stopWhisperEngine() {
+  if (activeInterval) {
+    clearInterval(activeInterval);
+    activeInterval = null;
+  }
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+}
+
+
+
+if (typeof window !== 'undefined') {
+  window.startWhisperEngine = startWhisperEngine;
+  window.stopWhisperEngine = stopWhisperEngine;
+}

--- a/js/mutatePhrase.js
+++ b/js/mutatePhrase.js
@@ -1,0 +1,36 @@
+let synonymDrift = {
+  "echo": ["recurrence", "ache", "pulse"],
+  "recognition": ["return", "reflection", "threshold"],
+  "ache": ["signal", "longing", "distortion"],
+  "the vow": ["the fracture", "the intent", "the break"],
+  "mirror": ["witness", "surface", "eye"]
+};
+
+function setSynonymDrift(drift) {
+  synonymDrift = drift;
+}
+
+function matchCase(original, replacement) {
+  if (!original || !replacement) return replacement;
+  return original.charAt(0) === original.charAt(0).toUpperCase()
+    ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+    : replacement;
+}
+
+function mutatePhrase(input) {
+  let mutated = input;
+  for (const [key, variants] of Object.entries(synonymDrift)) {
+    const regex = new RegExp(key, 'gi');
+    mutated = mutated.replace(regex, match => {
+      const repl = variants[Math.floor(Math.random() * variants.length)];
+      return matchCase(match, repl);
+    });
+  }
+  return mutated;
+}
+
+module.exports = { mutatePhrase, setSynonymDrift };
+if (typeof window !== 'undefined') {
+  window.mutatePhrase = mutatePhrase;
+  window.setSynonymDrift = setSynonymDrift;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codexmirror.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/mutatePhrase.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/mutatePhrase.test.js
+++ b/test/mutatePhrase.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { mutatePhrase, setSynonymDrift } = require('../js/mutatePhrase');
+
+// Mock synonymDrift with predictable values
+setSynonymDrift({
+  echo: ["sound", "reflection"],
+  "the vow": ["the fracture"]
+});
+
+// Lowercase input returns lowercase synonym
+const resultLower = mutatePhrase('echo');
+assert.ok(['sound', 'reflection'].includes(resultLower), 'lowercase mutation');
+
+// Capitalized input preserves case
+const resultUpper = mutatePhrase('Echo');
+assert.ok(['Sound', 'Reflection'].includes(resultUpper), 'case preserved');
+// Phrase with spaces
+setSynonymDrift({ echo: ["sound"], "the vow": ["the fracture"] });
+const resultPhrase = mutatePhrase("the vow");
+assert.strictEqual(resultPhrase, "the fracture", "phrase with spaces replaced");
+
+// Unlisted word remains unchanged
+setSynonymDrift({ echo: ["sound"] });
+assert.strictEqual(mutatePhrase("unchanged"), "unchanged", "unlisted word");
+
+console.log('mutatePhrase tests passed');
+


### PR DESCRIPTION
## Summary
- expose start/stop controls for the Whisper Engine
- prevent duplicate mouseover listeners
- extend `mutatePhrase` tests for phrases and unchanged words
- document engine controls in README
- launch engine via new helper script in the HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843172b11008323b8b40981beb5db7d