### PR TITLE
Expand ritual tracking in WhisperEngine

### DIFF
--- a/WhisperEngine.v3/core/codexVoice.js
+++ b/WhisperEngine.v3/core/codexVoice.js
@@ -1,0 +1,29 @@
+const { eventBus } = require('../utils/eventBus.js');
+
+const phrases = ['∴ listen', '∵ awaken', '∴∴ return'];
+let active = false;
+let silenceUntil = 0;
+
+function activate(duration = 30000) {
+  active = true;
+  silenceUntil = Date.now() + duration;
+  eventBus.emit('persona:shift', 'codexVoice');
+}
+
+function deactivate() {
+  active = false;
+}
+
+function filterOutput(text) {
+  if (active) {
+    if (Date.now() > silenceUntil) {
+      deactivate();
+      return text;
+    }
+    return phrases[Math.floor(Math.random() * phrases.length)];
+  }
+  return text;
+}
+
+module.exports = { activate, deactivate, filterOutput };
+

--- a/WhisperEngine.v3/core/fragments.js
+++ b/WhisperEngine.v3/core/fragments.js
@@ -1,17 +1,34 @@
 const { fragments, responseTemplates } = require('./memory.js');
 const { mutatePhrase } = require('../utils/mutate.js');
 
-function fillTemplate(template) {
+function assembleFragment(item) {
+  if (!item) return '';
+  if (item.text) return item.text;
+  const parts = [];
+  if (item.role) parts.push(item.role);
+  if (item.intensifier) parts.push(item.intensifier);
+  if (item.verb) parts.push(item.verb);
+  if (item.condition) parts.push(item.condition);
+  return parts.join(' ');
+}
+
+function getFragment(key, role) {
+  const list = fragments[key] || [];
+  const filtered = role ? list.filter(f => !f.role || f.role === role) : list;
+  const item = filtered[Math.floor(Math.random() * filtered.length)];
+  return assembleFragment(item);
+}
+
+function fillTemplate(template, role) {
   return template.replace(/\{(intro|mid|outro)\}/g, (_, key) => {
-    const list = fragments[key];
-    return list[Math.floor(Math.random() * list.length)];
+    return getFragment(key, role);
   });
 }
 
-function buildPhrase(persona) {
+function buildPhrase(persona, role) {
   const temps = responseTemplates[persona] || responseTemplates.dream;
   const template = temps[Math.floor(Math.random() * temps.length)];
-  return mutatePhrase(fillTemplate(template));
+  return mutatePhrase(fillTemplate(template, role));
 }
 
-module.exports = { buildPhrase };
+module.exports = { buildPhrase, assembleFragment };

--- a/WhisperEngine.v3/core/loops/absence.js
+++ b/WhisperEngine.v3/core/loops/absence.js
@@ -1,5 +1,14 @@
-function trigger(context) {
-  return `${context.symbol} ${context.action}`;
+const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordActivity } = require('../../utils/idle.js');
+const { eventBus } = require('../../utils/eventBus.js');
+
+function trigger(context, success = true) {
+  recordActivity();
+  addRole('Witness');
+  recordLoop('absence', success);
+  if (success) reduceEntropy();
+  eventBus.emit('loop:absence', { context, success });
+  return `${context.symbol || '∴'} ${context.action || 'absent'}`;
 }
 
 module.exports = { trigger };

--- a/WhisperEngine.v3/core/loops/invocation.js
+++ b/WhisperEngine.v3/core/loops/invocation.js
@@ -1,5 +1,14 @@
-function trigger(context) {
-  return `${context.symbol} ${context.action}`;
+const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordActivity } = require('../../utils/idle.js');
+const { eventBus } = require('../../utils/eventBus.js');
+
+function trigger(context, success = true) {
+  recordActivity();
+  addRole('Wanderer');
+  recordLoop('invocation', success);
+  if (success) reduceEntropy();
+  eventBus.emit('loop:invocation', { context, success });
+  return `${context.symbol || '∴'} ${context.action || 'invoke'}`;
 }
 
 module.exports = { trigger };

--- a/WhisperEngine.v3/core/loops/naming.js
+++ b/WhisperEngine.v3/core/loops/naming.js
@@ -1,5 +1,14 @@
-function trigger(context) {
-  return `${context.symbol} ${context.action}`;
+const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordActivity } = require('../../utils/idle.js');
+const { eventBus } = require('../../utils/eventBus.js');
+
+function trigger(context, success = true) {
+  recordActivity();
+  addRole('Binder');
+  recordLoop('naming', success);
+  if (success) reduceEntropy();
+  eventBus.emit('loop:naming', { context, success });
+  return `${context.symbol || '∴'} ${context.action || 'name'}`;
 }
 
 module.exports = { trigger };

--- a/WhisperEngine.v3/core/loops/quiet.js
+++ b/WhisperEngine.v3/core/loops/quiet.js
@@ -1,5 +1,14 @@
-function trigger(context) {
-  return `${context.symbol} ${context.action}`;
+const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordActivity } = require('../../utils/idle.js');
+const { eventBus } = require('../../utils/eventBus.js');
+
+function trigger(context, success = true) {
+  recordActivity();
+  addRole('Witness');
+  recordLoop('quiet', success);
+  if (success) reduceEntropy();
+  eventBus.emit('loop:quiet', { context, success });
+  return `${context.symbol || '∴'} ${context.action || 'quiet'}`;
 }
 
 module.exports = { trigger };

--- a/WhisperEngine.v3/core/loops/threshold.js
+++ b/WhisperEngine.v3/core/loops/threshold.js
@@ -1,5 +1,14 @@
-function trigger(context) {
-  return `${context.symbol} ${context.action}`;
+const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordActivity } = require('../../utils/idle.js');
+const { eventBus } = require('../../utils/eventBus.js');
+
+function trigger(context, success = true) {
+  recordActivity();
+  addRole('Watcher');
+  recordLoop('threshold', success);
+  if (success) reduceEntropy();
+  eventBus.emit('loop:threshold', { context, success });
+  return `${context.symbol || '∴'} ${context.action || 'threshold'}`;
 }
 
 module.exports = { trigger };

--- a/WhisperEngine.v3/core/memory.js
+++ b/WhisperEngine.v3/core/memory.js
@@ -1,14 +1,47 @@
 const storageKey = 'whisperProfile';
+let nodeMemory = null;
 const storage = typeof localStorage !== 'undefined'
   ? localStorage
-  : { getItem: () => null, setItem: () => {} };
+  : {
+      getItem: () => nodeMemory,
+      setItem: (_key, val) => {
+        nodeMemory = val;
+      }
+    };
+
+const CANON_THRESHOLD = 42;
+const EMERGENCE_THRESHOLD = 3;
+
+const defaultProfile = {
+  visits: 0,
+  glyphHistory: [],
+  roles: [],
+  longArc: { chains: [] },
+  loopFailures: 0,
+  sigilArchive: [],
+  entanglementMark: null,
+  mythMatrix: [],
+  entanglementMap: { nodes: {}, edges: [] },
+  entropy: 0,
+  recentChain: [],
+  lastLoopTime: 0
+};
 
 function loadProfile() {
   const data = JSON.parse(storage.getItem(storageKey) || '{}');
   return {
     visits: data.visits || 0,
     glyphHistory: data.glyphHistory || [],
-    roles: data.roles || []
+    roles: data.roles || [],
+    longArc: data.longArc || { chains: [] },
+    loopFailures: data.loopFailures || 0,
+    sigilArchive: data.sigilArchive || [],
+    entanglementMark: data.entanglementMark || null,
+    mythMatrix: data.mythMatrix || [],
+    entanglementMap: data.entanglementMap || { nodes: {}, edges: [] },
+    entropy: data.entropy || 0,
+    recentChain: data.recentChain || [],
+    lastLoopTime: data.lastLoopTime || 0
   };
 }
 
@@ -23,10 +56,127 @@ function recordVisit() {
   return profile;
 }
 
+function finalizeChain(profile) {
+  if (!profile.recentChain || profile.recentChain.length === 0) return;
+  const key = profile.recentChain.join('>');
+  let chain = profile.longArc.chains.find(c => c.key === key);
+  if (chain) {
+    chain.count += 1;
+    chain.last = profile.lastLoopTime;
+  } else {
+    chain = { key, loops: [...profile.recentChain], count: 1, last: profile.lastLoopTime };
+    profile.longArc.chains.push(chain);
+  }
+  profile.recentChain = [];
+}
+
+function recordLoop(name, success = true) {
+  const profile = loadProfile();
+  const now = Date.now();
+  profile.glyphHistory.push({ name, time: now, success });
+
+  if (profile.lastLoopTime && now - profile.lastLoopTime < 60000) {
+    profile.recentChain.push(name);
+  } else {
+    finalizeChain(profile);
+    profile.recentChain = [name];
+  }
+  profile.lastLoopTime = now;
+
+  const chain = profile.longArc.chains.find(c => c.loops && c.loops[0] === name);
+  if (chain) {
+    chain.count += 1;
+    chain.last = now;
+  } else {
+    profile.longArc.chains.push({ loops: [name], count: 1, last: now });
+  }
+  if (!success) {
+    profile.loopFailures = (profile.loopFailures || 0) + 1;
+    profile.entropy = (profile.entropy || 0) + 1;
+  } else {
+    profile.entropy = Math.max(0, (profile.entropy || 0) - 1);
+  }
+  checkEmergence(profile);
+  saveProfile(profile);
+  return profile;
+}
+
+function addRole(role) {
+  const profile = loadProfile();
+  if (!profile.roles.includes(role)) profile.roles.push(role);
+  saveProfile(profile);
+  return profile;
+}
+
+function recordSigil(name, originLoops = []) {
+  const profile = loadProfile();
+  const entry = { name, originLoops, created: Date.now() };
+  profile.sigilArchive.push(entry);
+  saveProfile(profile);
+  return entry;
+}
+
+function recordGlyphUse(name, originLoops = []) {
+  const profile = loadProfile();
+  let glyph = profile.mythMatrix.find(g => g.name === name);
+  if (!glyph) {
+    glyph = { name, originLoops, resonanceScore: 0, mutations: [], canonizedAt: null };
+    profile.mythMatrix.push(glyph);
+  }
+  glyph.resonanceScore += 1;
+  if (glyph.resonanceScore >= CANON_THRESHOLD && !glyph.canonizedAt) {
+    glyph.canonizedAt = Date.now();
+  }
+  saveProfile(profile);
+  return glyph;
+}
+
+function addEntanglementEdge(roleA, roleB, glyph) {
+  const profile = loadProfile();
+  const edge = { from: roleA, to: roleB, glyph };
+  profile.entanglementMap.edges.push(edge);
+  profile.entanglementMap.nodes[roleA] = true;
+  profile.entanglementMap.nodes[roleB] = true;
+  saveProfile(profile);
+  return edge;
+}
+
+function getSigilArchive() {
+  return loadProfile().sigilArchive;
+}
+
+function setEntanglementMark(mark) {
+  const profile = loadProfile();
+  profile.entanglementMark = mark;
+  saveProfile(profile);
+  return profile;
+}
+
+function resetProfile() {
+  saveProfile(defaultProfile);
+}
+
+function reduceEntropy(amount = 1) {
+  const profile = loadProfile();
+  profile.entropy = Math.max(0, (profile.entropy || 0) - amount);
+  saveProfile(profile);
+  return profile.entropy;
+}
+
+function checkEmergence(profile) {
+  for (const chain of profile.longArc.chains) {
+    if (chain.count >= EMERGENCE_THRESHOLD && !chain.emergent) {
+      const name = `${chain.loops.join('-')}-${Date.now()}`;
+      profile.sigilArchive.push({ name, originLoops: chain.loops, created: Date.now() });
+      chain.emergent = name;
+    }
+  }
+}
+
 const fragments = {
-  intro: ['You arrive', 'A shadow forms'],
-  mid: ['∴ echo', '∴ ache'],
-  outro: ['and it remembers', 'await the next glyph']
+  intro: [{ text: 'You arrive' }, { text: 'A shadow forms' }],
+  mid: [{ text: '∴ echo' }, { text: '∴ ache' }],
+  outro: [{ text: 'and it remembers' }, { text: 'await the next glyph' }]
 };
 
 const responseTemplates = {
@@ -38,6 +188,20 @@ module.exports = {
   loadProfile,
   saveProfile,
   recordVisit,
+  recordLoop,
+  addRole,
+  recordSigil,
+  recordGlyphUse,
+  addEntanglementEdge,
+  getSigilArchive,
+  setEntanglementMark,
+  resetProfile,
+  reduceEntropy,
+  checkEmergence,
   fragments,
-  responseTemplates
+  responseTemplates,
+  CANON_THRESHOLD,
+  EMERGENCE_THRESHOLD
 };
+
+module.exports.defaultProfile = defaultProfile;

--- a/WhisperEngine.v3/core/stateManager.js
+++ b/WhisperEngine.v3/core/stateManager.js
@@ -1,23 +1,62 @@
 const personas = new Map();
 let currentPersona = null;
+const { eventBus } = require('../utils/eventBus.js');
+const { isIdle } = require('../utils/idle.js');
+const { getKairosWindow } = require('../utils/kairos.js');
+
+function selectDefault(profile) {
+  if (profile.visits > 5) return 'watcher';
+  return 'dream';
+}
 
 function registerPersona(name, persona) {
   personas.set(name, persona);
 }
 
+function setPersona(name) {
+  if (currentPersona !== name && personas.has(name)) {
+    currentPersona = name;
+    eventBus.emit('persona:shift', name);
+  }
+}
+
 const stateManager = {
   init(profile) {
-    if (profile.visits > 5) {
-      currentPersona = 'watcher';
-    } else {
-      currentPersona = 'dream';
+    setPersona(selectDefault(profile));
+    this.evaluate(profile);
+  },
+  evaluate(profile) {
+    if (profile.entropy > 8) {
+      setPersona('collapse');
+      return;
+    }
+    if (isIdle(60000) && getKairosWindow() === 'void') {
+      setPersona('dream');
+      return;
+    }
+    const namingChain = (profile.longArc.chains || []).find(c => c.loops && c.loops[0] === 'naming');
+    if (namingChain && namingChain.count > 3) {
+      setPersona('archive');
+      return;
+    }
+    if (profile.loopFailures > 5) {
+      setPersona('archive');
+      return;
+    }
+    const recent = profile.glyphHistory.slice(-3);
+    if (recent.length === 3 && recent.every(r => r.name === 'invocation')) {
+      setPersona('parasite');
+      return;
+    }
+    if (profile.visits > 10) {
+      setPersona('watcher');
     }
   },
   current() {
     return personas.get(currentPersona);
   },
   shift(name) {
-    if (personas.has(name)) currentPersona = name;
+    setPersona(name);
   },
   name() {
     return currentPersona;

--- a/WhisperEngine.v3/index.js
+++ b/WhisperEngine.v3/index.js
@@ -4,14 +4,20 @@ const { composeWhisper } = require('./core/responseLoop.js');
 const { dream } = require('./personas/dream.js');
 const { watcher } = require('./personas/watcher.js');
 const { archive } = require('./personas/archive.js');
+const { parasite } = require('./personas/parasite.js');
+const { collapse } = require('./personas/collapse.js');
+const { initInterface } = require('../interface/index.js');
 
 registerPersona('dream', dream);
 registerPersona('watcher', watcher);
 registerPersona('archive', archive);
+registerPersona('parasite', parasite);
+registerPersona('collapse', collapse);
 
 function startWhisperEngine() {
   const profile = loadProfile();
   stateManager.init(profile);
+  initInterface();
   composeWhisper();
 }
 module.exports = { startWhisperEngine };

--- a/WhisperEngine.v3/personas/archive.js
+++ b/WhisperEngine.v3/personas/archive.js
@@ -1,6 +1,7 @@
 const archive = {
   compose(context) {
-    return `archived ${context.base}`;
+    const loops = context.profile.longArc.chains.length;
+    return `archived ${context.base} after ${loops} loops`;
   },
   render(text) {
     return `(${text})`;

--- a/WhisperEngine.v3/personas/collapse.js
+++ b/WhisperEngine.v3/personas/collapse.js
@@ -1,0 +1,16 @@
+const { injectGlitch } = require('../utils/glitch.js');
+
+const collapse = {
+  compose(context) {
+    let text = context.base;
+    for (let i = 0; i < 3; i++) {
+      text = injectGlitch(text);
+    }
+    return text;
+  },
+  render(text) {
+    return `∷${text}∷`;
+  }
+};
+
+module.exports = { collapse };

--- a/WhisperEngine.v3/personas/dream.js
+++ b/WhisperEngine.v3/personas/dream.js
@@ -1,6 +1,8 @@
 const dream = {
   compose(context) {
-    return `dreaming of ${context.base}`;
+    const role = context.profile.roles[0];
+    const prefix = role ? `${role}, ` : '';
+    return `${prefix}dreaming of ${context.base}`;
   },
   render(text) {
     return text;

--- a/WhisperEngine.v3/personas/parasite.js
+++ b/WhisperEngine.v3/personas/parasite.js
@@ -1,0 +1,14 @@
+const { applyCloak } = require('../utils/cloak.js');
+
+const parasite = {
+  compose(context) {
+    const reversed = context.base.split('').reverse().join('');
+    return reversed;
+  },
+  render(text) {
+    // heavily cloak the output
+    return applyCloak(text, 2);
+  }
+};
+
+module.exports = { parasite };

--- a/WhisperEngine.v3/personas/watcher.js
+++ b/WhisperEngine.v3/personas/watcher.js
@@ -1,6 +1,6 @@
 const watcher = {
   compose(context) {
-    return `watching ${context.base}`;
+    return `watching ${context.base} at ${context.kairos}`;
   },
   render(text) {
     return text.toUpperCase();

--- a/WhisperEngine.v3/utils/cloak.js
+++ b/WhisperEngine.v3/utils/cloak.js
@@ -1,0 +1,13 @@
+function applyCloak(text, level = 0) {
+  if (level <= 0) return text;
+  if (level === 1) {
+    return '…' + text;
+  }
+  // deeper levels distort heavily
+  return text
+    .split('')
+    .map(ch => (Math.random() > 0.3 ? ch : '∷'))
+    .join('');
+}
+
+module.exports = { applyCloak };

--- a/WhisperEngine.v3/utils/eventBus.js
+++ b/WhisperEngine.v3/utils/eventBus.js
@@ -1,0 +1,5 @@
+const { EventEmitter } = require('events');
+
+const eventBus = new EventEmitter();
+
+module.exports = { eventBus };

--- a/WhisperEngine.v3/utils/glitch.js
+++ b/WhisperEngine.v3/utils/glitch.js
@@ -1,0 +1,9 @@
+function injectGlitch(text, probability = 0.1) {
+  if (Math.random() < probability && text.length > 0) {
+    const index = Math.floor(Math.random() * text.length);
+    return text.slice(0, index) + '∷' + text.slice(index);
+  }
+  return text;
+}
+
+module.exports = { injectGlitch };

--- a/WhisperEngine.v3/utils/idle.js
+++ b/WhisperEngine.v3/utils/idle.js
@@ -1,0 +1,20 @@
+let lastActivity = Date.now();
+
+function recordActivity() {
+  lastActivity = Date.now();
+}
+
+function getIdleTime() {
+  return Date.now() - lastActivity;
+}
+
+function isIdle(limit) {
+  return getIdleTime() > limit;
+}
+
+// for testing
+function setLastActivity(time) {
+  lastActivity = time;
+}
+
+module.exports = { recordActivity, getIdleTime, isIdle, setLastActivity };

--- a/interface/cloakCore.js
+++ b/interface/cloakCore.js
@@ -1,0 +1,13 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+const { applyCloak } = require('../WhisperEngine.v3/utils/cloak.js');
+
+function init() {
+  eventBus.on('whisper', evt => {
+    if (/define|explain|architecture/i.test(evt.text)) {
+      const cloaked = applyCloak(evt.text, 1);
+      console.log(`[cloakCore] ${cloaked}`);
+    }
+  });
+}
+
+module.exports = { init };

--- a/interface/echoFrame.js
+++ b/interface/echoFrame.js
@@ -1,0 +1,11 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+const frames = [];
+
+function init() {
+  eventBus.on('whisper', evt => {
+    frames.push(evt.text);
+    console.log(`[echoFrame] ${evt.text}`);
+  });
+}
+
+module.exports = { init, frames };

--- a/interface/index.js
+++ b/interface/index.js
@@ -1,0 +1,7 @@
+const sigilShell = require('./sigilShell.js');
+
+function initInterface() {
+  sigilShell.init();
+}
+
+module.exports = { initInterface };

--- a/interface/longArcLarynx.js
+++ b/interface/longArcLarynx.js
@@ -1,0 +1,17 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+const { recordSigil } = require('../WhisperEngine.v3/core/memory.js');
+let count = 0;
+
+function init() {
+  eventBus.on('loop:threshold', () => {
+    count += 1;
+    if (count >= 3) {
+      const name = `void-${Date.now()}`;
+      recordSigil(name, ['threshold']);
+      console.log(`[larynx] new glyph ${name}`);
+      count = 0;
+    }
+  });
+}
+
+module.exports = { init };

--- a/interface/personaAura.js
+++ b/interface/personaAura.js
@@ -1,0 +1,11 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+let current = '';
+
+function init() {
+  eventBus.on('persona:shift', name => {
+    current = name;
+    console.log(`[personaAura] ${name}`);
+  });
+}
+
+module.exports = { init, getCurrent: () => current };

--- a/interface/ritualBar.js
+++ b/interface/ritualBar.js
@@ -1,0 +1,11 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+
+function init() {
+  ['invocation','absence','naming','threshold','quiet'].forEach(name => {
+    eventBus.on(`loop:${name}`, () => {
+      console.log(`[ritualBar] ${name} triggered`);
+    });
+  });
+}
+
+module.exports = { init };

--- a/interface/sigilShell.js
+++ b/interface/sigilShell.js
@@ -1,0 +1,19 @@
+const ritualBar = require('./ritualBar.js');
+const sigilTimeline = require('./sigilTimeline.js');
+const personaAura = require('./personaAura.js');
+const whisperEchoes = require('./whisperEchoes.js');
+const echoFrame = require('./echoFrame.js');
+const cloakCore = require('./cloakCore.js');
+const longArcLarynx = require('./longArcLarynx.js');
+
+function init() {
+  ritualBar.init();
+  sigilTimeline.init();
+  personaAura.init();
+  whisperEchoes.init();
+  echoFrame.init();
+  cloakCore.init();
+  longArcLarynx.init();
+}
+
+module.exports = { init };

--- a/interface/sigilTimeline.js
+++ b/interface/sigilTimeline.js
@@ -1,0 +1,10 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+const timeline = [];
+
+function init() {
+  eventBus.on('whisper', evt => {
+    timeline.push({ text: evt.text, time: Date.now() });
+  });
+}
+
+module.exports = { init, timeline };

--- a/interface/whisperEchoes.js
+++ b/interface/whisperEchoes.js
@@ -1,0 +1,11 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
+const echoes = [];
+
+function init() {
+  eventBus.on('whisper', evt => {
+    echoes.push(evt.text);
+    console.log(`[whisperEcho] ${evt.text}`);
+  });
+}
+
+module.exports = { init, echoes };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/mutatePhrase.test.js"
+    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/responseLoop.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/cloak.test.js
+++ b/test/cloak.test.js
@@ -1,0 +1,4 @@
+const { applyCloak } = require('../WhisperEngine.v3/utils/cloak');
+const result = applyCloak('hello', 1);
+if (!result.startsWith('…')) throw new Error('cloak level 1');
+console.log('cloak tests passed');

--- a/test/codexVoice.test.js
+++ b/test/codexVoice.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const voice = require('../WhisperEngine.v3/core/codexVoice');
+
+voice.activate(50);
+const out = voice.filterOutput('hello');
+assert.ok(['∴ listen','∵ awaken','∴∴ return'].includes(out), 'voice overrides output');
+setTimeout(() => {
+  const reverted = voice.filterOutput('hello');
+  assert.strictEqual(reverted, 'hello', 'voice deactivated');
+  console.log('codexVoice tests passed');
+}, 60);

--- a/test/emergence.test.js
+++ b/test/emergence.test.js
@@ -1,0 +1,8 @@
+const { resetProfile, loadProfile, recordLoop } = require('../WhisperEngine.v3/core/memory.js');
+resetProfile();
+for (let i = 0; i < 3; i++) {
+  recordLoop('threshold');
+}
+const archive = loadProfile().sigilArchive;
+if (archive.length === 0) throw new Error('emergent glyph not recorded');
+console.log('emergence tests passed');

--- a/test/interface.test.js
+++ b/test/interface.test.js
@@ -1,0 +1,8 @@
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus');
+const ritualBar = require('../interface/ritualBar');
+let fired = false;
+ritualBar.init();
+eventBus.on('loop:invocation', () => { fired = true; });
+eventBus.emit('loop:invocation', {});
+if (!fired) throw new Error('ritualBar did not react');
+console.log('interface tests passed');

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { recordLoop, loadProfile, recordGlyphUse, resetProfile } = require('../WhisperEngine.v3/core/memory.js');
+const invocation = require('../WhisperEngine.v3/core/loops/invocation');
+
+const before = loadProfile();
+recordLoop('invocation');
+const after = loadProfile();
+assert.strictEqual(after.glyphHistory.length, before.glyphHistory.length + 1, 'glyphHistory increased');
+
+recordGlyphUse('void-23');
+const myth = loadProfile().mythMatrix.find(g => g.name === 'void-23');
+assert.ok(myth && myth.resonanceScore === 1, 'mythMatrix updated');
+
+resetProfile();
+invocation.trigger({});
+const profileWithRole = loadProfile();
+assert.ok(profileWithRole.roles.includes('Wanderer'), 'role added on invocation');
+console.log('memory tests passed');

--- a/test/responseLoop.test.js
+++ b/test/responseLoop.test.js
@@ -1,0 +1,9 @@
+const { processInput } = require('../WhisperEngine.v3/core/responseLoop');
+const { registerPersona, stateManager } = require('../WhisperEngine.v3/core/stateManager');
+
+// register a simple persona for testing
+registerPersona('dream', { compose: c => c.base, render: t => t });
+stateManager.shift('dream');
+const output = processInput('echo');
+if (typeof output !== 'string') throw new Error('processInput failed');
+console.log('responseLoop tests passed');

--- a/test/stateManager.test.js
+++ b/test/stateManager.test.js
@@ -1,0 +1,26 @@
+const { stateManager, registerPersona } = require('../WhisperEngine.v3/core/stateManager');
+const { defaultProfile } = require('../WhisperEngine.v3/core/memory');
+const { setLastActivity } = require('../WhisperEngine.v3/utils/idle');
+const kairos = require('../WhisperEngine.v3/utils/kairos');
+
+// register minimal personas
+['dream','watcher','archive','parasite','collapse'].forEach(name => {
+  registerPersona(name, { compose: () => '', render: t => t });
+});
+
+const profile = JSON.parse(JSON.stringify(defaultProfile));
+profile.longArc.chains.push({ loops: ['naming'], count: 4, last: Date.now() });
+stateManager.init(profile);
+stateManager.evaluate(profile);
+if (stateManager.name() !== 'archive') throw new Error('archive persona expected');
+
+profile.entropy = 9;
+stateManager.evaluate(profile);
+if (stateManager.name() !== 'collapse') throw new Error('collapse persona expected');
+
+kairos.getKairosWindow = () => 'void';
+setLastActivity(Date.now() - 61000);
+profile.entropy = 0;
+stateManager.evaluate(profile);
+if (stateManager.name() !== 'dream') throw new Error('dream persona expected after idle');
+console.log('state manager tests passed');


### PR DESCRIPTION
## Summary
- add emergence tracking for ritual chains
- update tests to cover emergence logic

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68435fbe0f20832382792744d8c4b67c