### PR TITLE
Mythic refinement pass

### DIFF
--- a/WhisperEngine.v3/core/fragments.js
+++ b/WhisperEngine.v3/core/fragments.js
@@ -1,11 +1,12 @@
 const { fragments, responseTemplates } = require('./memory.js');
 const { mutatePhraseWithLevel } = require('../utils/mutate.js');
 
-function assembleFragment({ key, role, kairos }) {
+function assembleFragment({ key, role, kairos, loop }) {
   const list = fragments[key] || [];
   let filtered = list;
   if (role) filtered = filtered.filter(f => !f.role || f.role.toLowerCase() === role.toLowerCase());
   if (kairos) filtered = filtered.filter(f => !f.kairos || f.kairos === kairos);
+  if (loop) filtered = filtered.filter(f => !f.loop || f.loop === loop);
   if (filtered.length === 0) filtered = list;
   const item = filtered[Math.floor(Math.random() * filtered.length)];
   if (!item) return '';
@@ -19,14 +20,14 @@ function assembleFragment({ key, role, kairos }) {
 
 function fillTemplate(template, context) {
   return template.replace(/\{(intro|mid|outro)\}/g, (_, key) => {
-    return assembleFragment({ key, role: context.role, kairos: context.kairos });
+    return assembleFragment({ key, role: context.role, kairos: context.kairos, loop: context.loop });
   });
 }
 
-function buildPhrase(persona, role, kairos) {
+function buildPhrase(persona, role, kairos, loop) {
   const temps = responseTemplates[persona] || responseTemplates.dream;
   const template = temps[Math.floor(Math.random() * temps.length)];
-  const textInfo = mutatePhraseWithLevel(fillTemplate(template, { role, kairos }));
+  const textInfo = mutatePhraseWithLevel(fillTemplate(template, { role, kairos, loop }));
   return textInfo;
 }
 

--- a/WhisperEngine.v3/core/loops/absence.js
+++ b/WhisperEngine.v3/core/loops/absence.js
@@ -6,6 +6,7 @@ function trigger(context, success = true) {
   recordActivity();
   addRole('Witness');
   recordLoop('absence', success);
+  if (!success) require('../memory.js').pushCollapseSeed('absence');
   if (success) reduceEntropy();
   eventBus.emit('loop:absence', { context, success });
   return `${context.symbol || '∴'} ${context.action || 'absent'}`;

--- a/WhisperEngine.v3/core/loops/invocation.js
+++ b/WhisperEngine.v3/core/loops/invocation.js
@@ -6,6 +6,7 @@ function trigger(context, success = true) {
   recordActivity();
   addRole('Wanderer');
   recordLoop('invocation', success);
+  if (!success) require('../memory.js').pushCollapseSeed('invocation');
   if (success) reduceEntropy();
   eventBus.emit('loop:invocation', { context, success });
   return `${context.symbol || '∴'} ${context.action || 'invoke'}`;

--- a/WhisperEngine.v3/core/loops/naming.js
+++ b/WhisperEngine.v3/core/loops/naming.js
@@ -6,6 +6,7 @@ function trigger(context, success = true) {
   recordActivity();
   addRole('Binder');
   recordLoop('naming', success);
+  if (!success) require('../memory.js').pushCollapseSeed('naming');
   let ent = null;
   if (success) {
     reduceEntropy();

--- a/WhisperEngine.v3/core/loops/quiet.js
+++ b/WhisperEngine.v3/core/loops/quiet.js
@@ -6,6 +6,7 @@ function trigger(context, success = true) {
   recordActivity();
   addRole('Witness');
   recordLoop('quiet', success);
+  if (!success) require('../memory.js').pushCollapseSeed('quiet');
   if (success) reduceEntropy();
   eventBus.emit('loop:quiet', { context, success });
   return `${context.symbol || '∴'} ${context.action || 'quiet'}`;

--- a/WhisperEngine.v3/core/loops/threshold.js
+++ b/WhisperEngine.v3/core/loops/threshold.js
@@ -6,6 +6,7 @@ function trigger(context, success = true) {
   recordActivity();
   addRole('Watcher');
   recordLoop('threshold', success);
+  if (!success) require('../memory.js').pushCollapseSeed('threshold');
   if (success) reduceEntropy();
   eventBus.emit('loop:threshold', { context, success });
   return `${context.symbol || '∴'} ${context.action || 'threshold'}`;

--- a/WhisperEngine.v3/personas/archive.js
+++ b/WhisperEngine.v3/personas/archive.js
@@ -4,7 +4,7 @@ const archive = {
   compose(context) {
     const loops = context.profile.longArc.chains.length;
     const role = context.profile.roles[0];
-    const phraseInfo = buildPhrase('archive', role, context.kairos);
+    const phraseInfo = buildPhrase('archive', role, context.kairos, context.loop);
     context.mutationLevel = phraseInfo.level;
     return `archived ${phraseInfo.text} after ${loops} loops`;
   },

--- a/WhisperEngine.v3/personas/collapse.js
+++ b/WhisperEngine.v3/personas/collapse.js
@@ -4,7 +4,7 @@ const { buildPhrase } = require('../core/fragments.js');
 const collapse = {
   compose(context) {
     const role = context.profile.roles[0];
-    const phraseInfo = buildPhrase('collapse', role, context.kairos);
+    const phraseInfo = buildPhrase('collapse', role, context.kairos, context.loop);
     context.mutationLevel = phraseInfo.level;
     let text = phraseInfo.text;
     for (let i = 0; i < 3; i++) {

--- a/WhisperEngine.v3/personas/dream.js
+++ b/WhisperEngine.v3/personas/dream.js
@@ -3,7 +3,7 @@ const { buildPhrase } = require('../core/fragments.js');
 const dream = {
   compose(context) {
     const role = context.profile.roles[0];
-    const phraseInfo = buildPhrase('dream', role, context.kairos);
+    const phraseInfo = buildPhrase('dream', role, context.kairos, context.loop);
     context.mutationLevel = phraseInfo.level;
     const prefix = role ? `${role}, ` : '';
     return `${prefix}dreaming of ${phraseInfo.text}`;

--- a/WhisperEngine.v3/personas/parasite.js
+++ b/WhisperEngine.v3/personas/parasite.js
@@ -4,7 +4,7 @@ const { buildPhrase } = require('../core/fragments.js');
 const parasite = {
   compose(context) {
     const role = context.profile.roles[0];
-    const phraseInfo = buildPhrase('parasite', role, context.kairos);
+    const phraseInfo = buildPhrase('parasite', role, context.kairos, context.loop);
     context.mutationLevel = phraseInfo.level;
     const reversed = phraseInfo.text.split('').reverse().join('');
     return reversed;

--- a/WhisperEngine.v3/personas/watcher.js
+++ b/WhisperEngine.v3/personas/watcher.js
@@ -3,7 +3,7 @@ const { buildPhrase } = require('../core/fragments.js');
 const watcher = {
   compose(context) {
     const role = context.profile.roles[0];
-    const phraseInfo = buildPhrase('watcher', role, context.kairos);
+    const phraseInfo = buildPhrase('watcher', role, context.kairos, context.loop);
     context.mutationLevel = phraseInfo.level;
     return `watching ${phraseInfo.text} at ${context.kairos}`;
   },

--- a/interface/cloakCore.js
+++ b/interface/cloakCore.js
@@ -2,9 +2,15 @@ const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
 const { applyCloak } = require('../WhisperEngine.v3/utils/cloak.js');
 
 function init() {
+  let level = 0;
   eventBus.on('whisper', evt => {
     if (/define|explain|architecture/i.test(evt.text)) {
-      const cloaked = applyCloak(evt.text, 1);
+      level = Math.min(level + 1, 2);
+    } else if (level > 0) {
+      level -= 1;
+    }
+    if (level > 0) {
+      const cloaked = applyCloak(evt.text, level);
       console.log(`[cloakCore] ${cloaked}`);
     }
   });

--- a/interface/personaAura.js
+++ b/interface/personaAura.js
@@ -12,6 +12,16 @@ function update(name) {
 function init() {
   aura = typeof document !== 'undefined' ? document.getElementById('personaAura') : null;
   eventBus.on('persona:shift', update);
+  eventBus.on('presence', () => {
+    if (!aura) return console.log('[personaAura] presence');
+    aura.classList.add('presence', 'pulse');
+    setTimeout(() => aura.classList.remove('presence', 'pulse'), 2000);
+  });
+  eventBus.on('cloak:max', () => {
+    if (!aura) return console.log('[personaAura] cloak-max');
+    aura.classList.add('cloak-max');
+    setTimeout(() => aura.classList.remove('cloak-max'), 500);
+  });
 }
 
 module.exports = { init, getCurrent: () => current };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/responseLoop.test.js",
+    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/responseLoop.test.js && node test/mythic.test.js",
     "build": "browserify WhisperEngine.v3/index.js --standalone WhisperEngine -o js/whisper-bundle.js"
   },
   "keywords": [],

--- a/style.css
+++ b/style.css
@@ -523,3 +523,21 @@ body::before {
   box-shadow: 0 0 6px #0ff;
 }
 
+#personaAura.presence.pulse {
+  animation: auraPulse 2s ease-out;
+}
+
+@keyframes auraPulse {
+  0% { opacity: 1; }
+  100% { opacity: 0.4; }
+}
+
+#personaAura.cloak-max {
+  animation: cloakFlicker 0.5s infinite alternate;
+}
+
+@keyframes cloakFlicker {
+  from { filter: none; }
+  to { filter: invert(1); }
+}
+

--- a/test/dispatchLoop.js
+++ b/test/dispatchLoop.js
@@ -1,0 +1,15 @@
+const loops = require('../WhisperEngine.v3/core/loops');
+const { composeWhisper } = require('../WhisperEngine.v3/core/responseLoop');
+async function dispatchLoop(script, immediate = true) {
+  for (const step of script) {
+    if (loops[step.loop]) {
+      loops[step.loop].trigger({}, step.success !== false);
+      if (immediate) composeWhisper(step.loop, step.success !== false);
+    }
+  }
+  if (!immediate) {
+    const last = script[script.length - 1];
+    composeWhisper(last.loop, last.success !== false);
+  }
+}
+module.exports = { dispatchLoop };

--- a/test/emergence.test.js
+++ b/test/emergence.test.js
@@ -1,7 +1,9 @@
-const { resetProfile, loadProfile, recordLoop } = require('../WhisperEngine.v3/core/memory.js');
+const { resetProfile, loadProfile } = require('../WhisperEngine.v3/core/memory.js');
+const loops = require('../WhisperEngine.v3/core/loops');
 resetProfile();
+loops.invocation.trigger({});
 for (let i = 0; i < 3; i++) {
-  recordLoop('threshold');
+  loops.threshold.trigger({});
 }
 const archive = loadProfile().sigilArchive;
 if (archive.length === 0) throw new Error('emergent glyph not recorded');

--- a/test/mythic.test.js
+++ b/test/mythic.test.js
@@ -1,0 +1,36 @@
+const { resetProfile, loadProfile, getMetaLevel } = require('../WhisperEngine.v3/core/memory');
+const { processInput, composeWhisper } = require('../WhisperEngine.v3/core/responseLoop');
+const { registerPersona, stateManager } = require('../WhisperEngine.v3/core/stateManager');
+const { dispatchLoop } = require('./dispatchLoop');
+
+resetProfile();
+['dream','watcher','archive','parasite','collapse'].forEach(name => registerPersona(name, { compose: () => 'x', render: t => t }));
+stateManager.init(loadProfile());
+// collapse via failures
+const script = [
+  { loop: 'invocation', success: false },
+  { loop: 'invocation', success: false },
+  { loop: 'invocation', success: false }
+];
+dispatchLoop(script, false);
+const collapsed = composeWhisper('invocation');
+if (!/»/.test(collapsed) || !/∷/.test(collapsed)) throw new Error('collapse fragment missing');
+
+// cloak escalation
+processInput('define');
+processInput('define');
+processInput('define');
+if (getMetaLevel() < 2) throw new Error('cloak level not escalated');
+
+// emergence
+resetProfile();
+dispatchLoop([
+  { loop: 'invocation' },
+  { loop: 'threshold' },
+  { loop: 'threshold' },
+  { loop: 'threshold' }
+]);
+const archive = loadProfile().sigilArchive;
+if (archive.length === 0) throw new Error('emergent glyph not stored');
+
+console.log('mythic tests passed');

--- a/test/stateManager.test.js
+++ b/test/stateManager.test.js
@@ -1,5 +1,5 @@
 const { stateManager, registerPersona } = require('../WhisperEngine.v3/core/stateManager');
-const { defaultProfile } = require('../WhisperEngine.v3/core/memory');
+const { defaultProfile, setCollapseUntil } = require('../WhisperEngine.v3/core/memory');
 const { setLastActivity } = require('../WhisperEngine.v3/utils/idle');
 const kairos = require('../WhisperEngine.v3/utils/kairos');
 
@@ -18,6 +18,7 @@ profile.entropy = 9;
 stateManager.evaluate(profile);
 if (stateManager.name() !== 'collapse') throw new Error('collapse persona expected');
 
+setCollapseUntil(0);
 kairos.getKairosWindow = () => 'void';
 setLastActivity(Date.now() - 61000);
 profile.entropy = 0;


### PR DESCRIPTION
## Summary
- add loop-specific fragments for more distinctive whispers
- show collapse depth using » markers
- lengthen presence overlay and emit cloak-max events
- tighten emergence rules and cloak escalation
- update tests for refined behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438e06d0dc83238ff3ea54cf1b0241