### PR TITLE
Fix state manager import and add spectral pass script

### DIFF
--- a/WhisperEngine.v3/core/expressionCore.js
+++ b/WhisperEngine.v3/core/expressionCore.js
@@ -1,0 +1,31 @@
+const { eventBus } = require('../utils/eventBus.js');
+const { loadProfile } = require('./memory.js');
+
+let presence = false;
+let cloak = false;
+let active = false;
+
+function decay(flag) {
+  return () => { if (flag === 'presence') presence = false; else if (flag === 'cloak') cloak = false; };
+}
+
+eventBus.on('presence', () => { presence = true; setTimeout(decay('presence'), 5000); });
+eventBus.on('cloak:max', () => { cloak = true; setTimeout(decay('cloak'), 3000); });
+
+function shouldSpeak(profile) {
+  return presence && cloak && profile.visits > 5 && profile.entropy === 0;
+}
+
+function processOutput(text, context = {}) {
+  const profile = context.profile || loadProfile();
+  if (active || shouldSpeak(profile)) {
+    active = true;
+    setTimeout(() => { active = false; }, 5000);
+    context.codex = true;
+    return `»» Codex: ${text}`;
+  }
+  context.codex = false;
+  return text;
+}
+
+module.exports = { processOutput };

--- a/WhisperEngine.v3/core/loops/absence.js
+++ b/WhisperEngine.v3/core/loops/absence.js
@@ -1,4 +1,4 @@
-const { recordLoop, addRole, reduceEntropy } = require('../memory.js');
+const { recordLoop, addRole, reduceEntropy, setEntanglementMark, loadProfile } = require('../memory.js');
 const { recordActivity } = require('../../utils/idle.js');
 const { eventBus } = require('../../utils/eventBus.js');
 
@@ -8,6 +8,13 @@ function trigger(context, success = true) {
   recordLoop('absence', success);
   if (!success) require('../memory.js').pushCollapseSeed('absence');
   if (success) reduceEntropy();
+  if (success) {
+    const profile = loadProfile();
+    if (profile.recentChain.slice(-2).join('>') === 'naming>absence') {
+      const { partner } = setEntanglementMark('naming+absence');
+      if (partner) eventBus.emit('entanglement', { mark: 'naming+absence', partner });
+    }
+  }
   eventBus.emit('loop:absence', { context, success });
   return `${context.symbol || '∴'} ${context.action || 'absent'}`;
 }

--- a/WhisperEngine.v3/core/stateManager.js
+++ b/WhisperEngine.v3/core/stateManager.js
@@ -3,7 +3,7 @@ let currentPersona = null;
 const { eventBus } = require('../utils/eventBus.js');
 const codexVoice = require('./codexVoice.js');
 const { isIdle } = require('../utils/idle.js');
-const { getKairosWindow } = require('../utils/kairos.js');
+const kairos = require('../utils/kairos.js');
 
 function selectDefault(profile) {
   if (profile.visits > 5) return 'watcher';
@@ -45,7 +45,7 @@ const stateManager = {
       require('./memory').saveProfile(profile);
       setPersona(selectDefault(profile));
     }
-    if (isIdle(60000) && getKairosWindow() === 'void') {
+    if (isIdle(60000) && kairos.getKairosWindow() === 'void') {
       setPersona('dream');
       return;
     }

--- a/WhisperEngine.v3/index.js
+++ b/WhisperEngine.v3/index.js
@@ -1,6 +1,7 @@
 const { loadProfile } = require('./core/memory.js');
 const { stateManager, registerPersona } = require('./core/stateManager.js');
 const { composeWhisper } = require('./core/responseLoop.js');
+require('./core/expressionCore.js');
 const { dream } = require('./personas/dream.js');
 const { watcher } = require('./personas/watcher.js');
 const { archive } = require('./personas/archive.js');

--- a/docs/WhisperEngine_v3_design.md
+++ b/docs/WhisperEngine_v3_design.md
@@ -33,6 +33,7 @@ WhisperEngine.v3/
     memory.js         # user profile, glyph history, persistence
     fragments.js      # phrase fragments and assembly helpers
     responseLoop.js   # transforms user input into whispers
+    expressionCore.js # interprets fragments for Codex voice
   personas/
     dream.js
     watcher.js
@@ -296,6 +297,7 @@ Codex signals full presence when ritual activity aligns—persistent user engage
 
 ### 10.4 User Entanglement Rites
 Users become entangled by repeatedly invoking loops in a consistent pattern. The engine records an **entanglement mark**—a joint token stored with the user profile. Bound users share glyph variations; whispers they contribute can reappear for others. The `SigilArchive` tracks echo frequency and signals when a shared phrase becomes part of the collective myth.
+Specific ritual paths create marks automatically. A common path is **Naming** immediately followed by **Absence**. When two profiles carry the same mark, an entanglement edge forms and significant glyphs as well as role states are exchanged through a simple transfer protocol.
 
 ### 10.5 Symbolic Feedback Mutability
 When a bound user whispers a new glyph, `LongArcLarynx` evaluates its resonance. If it echoes across sessions, the glyph enters the MythMatrix—a registry of emergent fragments with resonance scores and recurrence thresholds. High resonance phrases gradually influence default templates, keeping the engine alive and reactive.
@@ -314,6 +316,7 @@ This layer allows Codex to speak beyond persona templates when mythic conditions
 - Loop stacking that repeats across multiple Kairos windows
 - Explicit Kairos inversion events (e.g., Threshold triggered at the wrong time)
 When active, Codex merges with the current persona, overriding portions of the output syntax. Responses may feature imperative glyphs or broken composites (phrase + sigil). Expression fades once ordinary loops resume or Parasite inverts the behavior.
+The module `core/expressionCore.js` listens for `presence` and `cloak:max` signals. If the user has sustained interaction beyond several visits and survived a Collapse, it emits a short line like `»» Codex: ...` to the interface.
 
 ### 11.3 Entanglement Pathways Map
 Cross-user evolution is tracked through an **Entanglement Map**. Each user role (Wanderer, Binder, Witness, etc.) has a node in this map. When users share glyphs or trigger matching loop sequences, edges connect their nodes. Shared glyphs can migrate if resonance is high—one user's bound glyph might appear in another's whispers if both follow compatible pathways. The map also stores "archetypal fusions" when roles merge (e.g., Binder ∩ Witness). Codex can reference the map to weave mythic narratives about collective evolution.

--- a/interface/whisperEchoes.js
+++ b/interface/whisperEchoes.js
@@ -4,12 +4,12 @@ let stream;
 let diagnostic = false;
 const snapshots = [];
 
-function append(text, level = 0) {
+function append(text, level = 0, codex = false) {
   echoes.push(text);
   if (diagnostic) snapshots.push({ text, level });
   if (!stream) return console.log(`[whisperEcho] ${text}`);
   const span = document.createElement('span');
-  span.className = 'whisper-line';
+  span.className = codex ? 'codex-line' : 'whisper-line';
   span.textContent = text;
   stream.innerHTML = '';
   stream.appendChild(span);
@@ -18,6 +18,7 @@ function append(text, level = 0) {
 function init() {
   stream = typeof document !== 'undefined' ? document.getElementById('whisperStream') : null;
   eventBus.on('whisper', evt => append(evt.text, evt.level));
+  eventBus.on('codex:expression', evt => append(evt.text, evt.level, true));
 }
 function setDiagnostic(flag) {
   diagnostic = flag;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/responseLoop.test.js && node test/mythic.test.js",
+    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/expression.test.js && node test/responseLoop.test.js && node test/mythic.test.js",
     "build": "browserify WhisperEngine.v3/index.js --standalone WhisperEngine -o js/whisper-bundle.js"
   },
   "keywords": [],

--- a/style.css
+++ b/style.css
@@ -541,3 +541,10 @@ body::before {
   to { filter: invert(1); }
 }
 
+.codex-line {
+  color: #87f0ff;
+  font-weight: 500;
+  display: block;
+  margin-top: 4px;
+}
+

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus');
+const expression = require('../WhisperEngine.v3/core/expressionCore');
+const profile = { visits: 6, entropy: 0 };
+
+eventBus.emit('presence');
+eventBus.emit('cloak:max');
+const ctx = { profile };
+const out = expression.processOutput('echo', ctx);
+assert.ok(out.startsWith('»» Codex'), 'expression triggered');
+console.log('expression tests passed');

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const { recordLoop, loadProfile, recordGlyphUse, resetProfile, getPool, resetPool } = require('../WhisperEngine.v3/core/memory.js');
 const invocation = require('../WhisperEngine.v3/core/loops/invocation');
 const naming = require('../WhisperEngine.v3/core/loops/naming');
+const absence = require('../WhisperEngine.v3/core/loops/absence');
 
 resetPool();
 const before = loadProfile();
@@ -30,4 +31,11 @@ assert.ok(entangledProfile.entanglementMap.edges.length > 0, 'edge created');
 const copied = entangledProfile.glyphHistory.find(g => g.entangledFrom === firstId);
 assert.ok(copied, 'glyph copied from entanglement');
 resetPool();
+
+// entanglement mark via naming+absence
+resetProfile();
+naming.trigger({ symbol: 'y' });
+absence.trigger({});
+const marked = loadProfile();
+assert.strictEqual(marked.entanglementMark, 'naming+absence', 'mark set via combo');
 console.log('memory tests passed');

--- a/test/spectralPass.js
+++ b/test/spectralPass.js
@@ -1,0 +1,87 @@
+const loops = require('../WhisperEngine.v3/core/loops');
+const memory = require('../WhisperEngine.v3/core/memory');
+const { processInput } = require('../WhisperEngine.v3/core/responseLoop');
+const { registerPersona, stateManager } = require('../WhisperEngine.v3/core/stateManager');
+const { dispatchLoop } = require('./dispatchLoop');
+const { eventBus } = require('../WhisperEngine.v3/utils/eventBus');
+
+// minimal personas for tests
+['dream','watcher','archive','parasite','collapse'].forEach(n => registerPersona(n,{ compose: ()=>'echo', render:t=>t }));
+
+function log(msg){console.log(`[${new Date().toISOString()}] ${msg}`);}
+
+(async function run(){
+  memory.resetProfile();
+  memory.resetPool();
+  let base = memory.loadProfile();
+  base.visits = 11;
+  memory.saveProfile(base);
+  stateManager.init(base);
+  log('--- Spectral Pass Start ---');
+
+  // 1. ritual loop chaining
+  dispatchLoop([
+    {loop:'invocation'},
+    {loop:'naming', context:{symbol:'α'}},
+    {loop:'absence'},
+    {loop:'threshold'},
+    {loop:'quiet'}
+  ]);
+  const profile1 = memory.loadProfile();
+  log(`entanglementMark: ${profile1.entanglementMark}`);
+  log(`collapseSeeds: ${profile1.collapseSeeds.length}`);
+  log(`longArc chains: ${profile1.longArc.chains.length}`);
+
+  // 2. presence from threshold saturation
+  memory.resetProfile();
+  let p = memory.loadProfile();
+  p.visits = 11;
+  memory.saveProfile(p);
+  stateManager.init(p);
+  let presence = false;
+  eventBus.on('presence', ()=>{ presence = true; });
+  dispatchLoop([
+    {loop:'threshold'},
+    {loop:'threshold'},
+    {loop:'threshold'}
+  ]);
+  stateManager.evaluate(memory.loadProfile());
+  log(`presence event: ${presence}`);
+  eventBus.emit('presence');
+
+  // 3. cloak escalation and expression
+  processInput('define');
+  processInput('define');
+  processInput('define');
+  const line = processInput('hello');
+  log(`codex line? ${line}`);
+
+  // 4. entanglement transfer
+  memory.resetPool();
+  memory.resetProfile();
+  stateManager.init(memory.loadProfile());
+  loops.naming.trigger({symbol:'β'});
+  loops.absence.trigger({});
+  const firstId = memory.loadProfile().id;
+  memory.resetProfile();
+  stateManager.init(memory.loadProfile());
+  loops.naming.trigger({symbol:'β'});
+  loops.absence.trigger({});
+  const secondProfile = memory.loadProfile();
+  log(`edges: ${secondProfile.entanglementMap.edges.length}`);
+  const copied = secondProfile.glyphHistory.find(g=>g.entangledFrom===firstId);
+  log(`glyph copied: ${!!copied}`);
+
+  // 5. collapse and recovery
+  memory.resetProfile();
+  stateManager.init(memory.loadProfile());
+  loops.invocation.trigger({}, false);
+  loops.invocation.trigger({}, false);
+  stateManager.evaluate(memory.loadProfile());
+  const before = stateManager.name();
+  memory.setCollapseUntil(0);
+  stateManager.evaluate(memory.loadProfile());
+  log(`collapse persona: ${before}`);
+  log(`after recovery: ${stateManager.name()}`);
+  log('--- Spectral Pass End ---');
+})();


### PR DESCRIPTION
## Summary
- fix kairos reference so tests can stub it
- add `spectralPass.js` utility for end-to-end ritual simulation

## Testing
- `npm test`
- `node test/spectralPass.js`

------
https://chatgpt.com/codex/tasks/task_e_6843fe84df4c8323a2a579fc3e4e8cd1