### PR TITLE
Bind ambient whispers to ritual glyphs

### DIFF
--- a/WhisperEngine.v3/index.js
+++ b/WhisperEngine.v3/index.js
@@ -1,6 +1,7 @@
 const { loadProfile } = require('./core/memory.js');
 const { stateManager, registerPersona } = require('./core/stateManager.js');
 const { composeWhisper } = require('./core/responseLoop.js');
+const loops = require('./core/loops');
 require('./core/expressionCore.js');
 const { dream } = require('./personas/dream.js');
 const { watcher } = require('./personas/watcher.js');
@@ -37,4 +38,12 @@ function stopWhisperEngine() {
   started = false;
 }
 
-module.exports = { startWhisperEngine, stopWhisperEngine };
+function glyph(symbol = '', charge = 0, opts = {}) {
+  const context = Object.assign({ symbol, charge }, opts);
+  if (loops && loops.invocation) {
+    loops.invocation.trigger(context, true);
+  }
+  return composeWhisper('invocation');
+}
+
+module.exports = { startWhisperEngine, stopWhisperEngine, glyph };

--- a/entities.html
+++ b/entities.html
@@ -6,6 +6,7 @@
   <title>∴ The Codex: Symbolic Entities</title>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css?v=codex-refactor-v3" />
+  <link rel="stylesheet" href="interface/ritualAura.css" />
   <link rel="stylesheet" href="css/codex-whisper.css" />
 </head>
 <body data-status="awake">
@@ -41,6 +42,7 @@
   </div>
 
   <div id="invocation-output"></div>
+  <div id="glyph-charge" class="glyph-charge-bar"><div class="fill"></div></div>
 
   <section class="codex-echo-ritual">
     <h2 class="ritual-label">∴ Invocation Drift</h2>
@@ -77,12 +79,20 @@
   <a href="html/privacy.html" style="color:#666;">Privacy</a>
 </footer>
 
+<script src="/js/ritualCharge.js"></script>
+<script src="/js/whisperLog.js"></script>
+<script src="/js/summonEffects.js"></script>
+<script src="/js/bloomController.js"></script>
+<script src="/js/audioLayer.js"></script>
 <script src="/js/invocation-engine.js" defer></script>
 <script src="/js/random-shard-picker.js"></script>
 <script src="js/whisper-bundle.js"></script>
 <script>
   if (window.WhisperEngine && typeof window.WhisperEngine.startWhisperEngine === 'function') {
     window.WhisperEngine.startWhisperEngine();
+  }
+  if (window.bloomController && typeof window.bloomController.startGlyphDrift === 'function') {
+    window.bloomController.startGlyphDrift();
   }
 </script>
 </body>

--- a/interface/ritualAura.css
+++ b/interface/ritualAura.css
@@ -1,0 +1,58 @@
+.reveal-stage-1 { opacity: 0.25; }
+.reveal-stage-2 { opacity: 0.5; filter: drop-shadow(0 0 4px #ccc); }
+.reveal-stage-3 { opacity: 0.75; filter: drop-shadow(0 0 6px #ddd); }
+.reveal-stage-4 { opacity: 1; filter: drop-shadow(0 0 8px #fff); }
+
+.entity-sigil-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  animation: sigilIgnite 1.2s forwards;
+}
+
+@keyframes sigilIgnite {
+  from { opacity: 1; }
+  to { opacity: 0; transform: scale(1.2); }
+}
+
+.glyph-charge-bar { height: 4px; background: #333; margin: 6px 0; position: relative; overflow: hidden; }
+.glyph-charge-bar .fill { height: 100%; width: 0; background: #e0e; transition: width 0.3s linear; }
+
+.whisper-fragment { font-style: italic; opacity: 0.8; animation: fragmentFade 2s forwards; }
+@keyframes fragmentFade {
+  from { opacity: 0.8; }
+  to { opacity: 0; }
+}
+
+/* Ambient bloom levels */
+body[class*="bloom-level-"] { transition: background-color 0.5s ease; }
+body.bloom-level-1 { background-color: #0a0a12; }
+body.bloom-level-2 { background-color: #0a0a14; }
+body.bloom-level-3 { background-color: #0a0a18; }
+body.bloom-level-4 { background-color: #0a0a1e; }
+body.bloom-level-5 { background-color: #0a0a24; }
+
+.bloom-pulse { animation: bloomPulse 1s ease-out; }
+@keyframes bloomPulse {
+  from { box-shadow: 0 0 4px #99f; }
+  to { box-shadow: 0 0 12px #ccf; }
+}
+
+/* Glyph drift */
+.glyph-row.drifting .glyph-btn { animation: glyphDrift 6s ease-in-out infinite alternate; }
+@keyframes glyphDrift {
+  0% { transform: translate(0,0) rotate(0deg); }
+  100% { transform: translate(3px,-3px) rotate(1deg); }
+}
+
+#invocation-output { position: relative; }
+.phantom-echo { position: absolute; left:50%; transform: translateX(-50%); font-style: italic; color:#bbb; opacity:0.8; pointer-events:none; animation: echoFade 3s forwards; }
+.phantom-echo.intensity-1 { opacity: 0.4; }
+.phantom-echo.intensity-2 { opacity: 0.6; }
+.phantom-echo.intensity-3 { opacity: 0.8; }
+.phantom-echo.intensity-4 { opacity: 1; font-weight: bold; }
+.phantom-echo.intensity-5 { opacity: 1; font-weight: bold; text-shadow: 0 0 6px #f9f; }
+@keyframes echoFade { from { opacity:0.8; } to { opacity:0; transform: translate(-50%,-20px);} }
+.collapse-overlay { position: fixed; inset:0; pointer-events:none; background: rgba(255,255,255,0.2); animation: collapseFlash 0.4s forwards; }
+@keyframes collapseFlash { from { opacity:1; } to { opacity:0; } }
+.collapse-fragment { font-style: italic; color:#c33; opacity:0.9; }

--- a/js/audioLayer.js
+++ b/js/audioLayer.js
@@ -1,0 +1,36 @@
+let drone, failure, glitchAudio;
+
+function init() {
+  if (typeof Audio === 'undefined') return;
+  drone = new Audio('media/static-loop-fracture.mp3');
+  drone.loop = true;
+  drone.volume = 0;
+  drone.play().catch(() => {});
+  failure = new Audio('media/bird-glitch.mp3');
+  glitchAudio = new Audio('media/bird-glitch.mp3');
+}
+
+function updateCharge(level) {
+  if (!drone) return;
+  drone.volume = Math.min(1, level / 5) * 0.4;
+}
+
+function collapseFeedback() {
+  if (drone) drone.volume = 0;
+  if (failure) {
+    failure.currentTime = 0;
+    failure.play();
+  }
+}
+
+function glitch() {
+  if (!glitchAudio) return;
+  glitchAudio.currentTime = 0;
+  glitchAudio.play();
+}
+
+init();
+
+const api = { updateCharge, collapseFeedback, glitch };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.audioLayer = api;

--- a/js/bloomController.js
+++ b/js/bloomController.js
@@ -1,0 +1,35 @@
+let level = 0;
+
+function setLevel(l) {
+  if (typeof document === 'undefined') return;
+  const body = document.body;
+  body.classList.remove(`bloom-level-${level}`);
+  level = l;
+  body.classList.add(`bloom-level-${level}`);
+}
+
+function entityBloom(id) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.add('bloom-pulse');
+  setTimeout(() => el.classList.remove('bloom-pulse'), 1200);
+}
+
+let driftTimer;
+function startGlyphDrift() {
+  if (typeof document === 'undefined') return;
+  const row = document.querySelector('.glyph-row');
+  if (!row) return;
+  const reset = () => {
+    clearTimeout(driftTimer);
+    row.classList.remove('drifting');
+    driftTimer = setTimeout(() => row.classList.add('drifting'), 4000);
+  };
+  ['click','mousemove'].forEach(evt => row.addEventListener(evt, reset));
+  reset();
+}
+
+const api = { setLevel, entityBloom, startGlyphDrift };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.bloomController = api;

--- a/js/ritualCharge.js
+++ b/js/ritualCharge.js
@@ -1,0 +1,29 @@
+const SEQ_LENGTH = 5;
+let sequence = [];
+
+function incrementCharge(glyph) {
+  sequence.push(glyph);
+  if (sequence.length > SEQ_LENGTH) sequence.shift();
+  return sequence.length;
+}
+
+function resetCharge() {
+  sequence = [];
+}
+
+function getCurrentCharge() {
+  return sequence.length;
+}
+
+function isSequenceComplete(pattern = []) {
+  if (pattern.length !== SEQ_LENGTH) return false;
+  if (sequence.length !== SEQ_LENGTH) return false;
+  for (let i = 0; i < SEQ_LENGTH; i++) {
+    if (sequence[i] !== pattern[i]) return false;
+  }
+  return true;
+}
+
+const api = { incrementCharge, resetCharge, getCurrentCharge, isSequenceComplete };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.ritualCharge = api;

--- a/js/summonEffects.js
+++ b/js/summonEffects.js
@@ -1,0 +1,18 @@
+function triggerExtendedBloom(entityId) {
+  if (typeof document === 'undefined') return;
+  const el = document.getElementById(entityId);
+  if (!el) return;
+  el.classList.add('extended-bloom');
+  setTimeout(() => el.classList.remove('extended-bloom'), 4000);
+}
+
+function initiateAmbientOverlay(state) {
+  if (typeof document === 'undefined') return;
+  const body = document.body;
+  body.classList.add(`ambient-${state}`);
+  setTimeout(() => body.classList.remove(`ambient-${state}`), 4000);
+}
+
+const api = { triggerExtendedBloom, initiateAmbientOverlay };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.summonEffects = api;

--- a/js/whisperLog.js
+++ b/js/whisperLog.js
@@ -1,0 +1,44 @@
+const STORE_KEY = 'ritualChronicle';
+
+function logSequence(sequence) {
+  if (typeof localStorage === 'undefined') return;
+  const log = JSON.parse(localStorage.getItem(STORE_KEY) || '[]');
+  log.push({ sequence, time: Date.now() });
+  localStorage.setItem(STORE_KEY, JSON.stringify(log));
+}
+
+function getRitualHistory() {
+  if (typeof localStorage === 'undefined') return [];
+  return JSON.parse(localStorage.getItem(STORE_KEY) || '[]');
+}
+
+function renderChronicle(container) {
+  const logs = getRitualHistory();
+  if (!container) return logs;
+  container.innerHTML = '';
+  logs.slice(-20).forEach(entry => {
+    const div = document.createElement('div');
+    div.className = 'ritual-log-entry';
+    div.textContent = entry.sequence.join(' ');
+    container.appendChild(div);
+  });
+  return logs;
+}
+
+function spawnPhantom(containerId, level = 1) {
+  if (typeof document === 'undefined') return;
+  const logs = getRitualHistory();
+  if (!logs.length) return;
+  const entry = logs[Math.floor(Math.random() * logs.length)];
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const div = document.createElement('div');
+  div.className = 'phantom-echo intensity-' + level;
+  div.textContent = entry.sequence.join(' ');
+  container.appendChild(div);
+  setTimeout(() => div.remove(), 3000);
+}
+
+const api = { logSequence, getRitualHistory, renderChronicle, spawnPhantom };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.whisperLog = api;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/expression.test.js && node test/responseLoop.test.js && node test/mythic.test.js",
+    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/expression.test.js && node test/responseLoop.test.js && node test/mythic.test.js && node test/ritualSequence.test.js",
     "build": "browserify WhisperEngine.v3/index.js --standalone WhisperEngine -o js/whisper-bundle.js"
   },
   "keywords": [],

--- a/test/ritualSequence.test.js
+++ b/test/ritualSequence.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const { incrementCharge, resetCharge, getCurrentCharge, isSequenceComplete } = require('../js/ritualCharge');
+
+resetCharge();
+incrementCharge('1');
+incrementCharge('2');
+incrementCharge('3');
+incrementCharge('4');
+assert.strictEqual(getCurrentCharge(), 4, 'charge tracks length');
+
+incrementCharge('5');
+assert.ok(isSequenceComplete(['1','2','3','4','5']), 'sequence matches');
+
+resetCharge();
+assert.strictEqual(getCurrentCharge(), 0, 'reset clears');
+
+console.log('ritualSequence tests passed');


### PR DESCRIPTION
## Summary
- export new `glyph` method from WhisperEngine
- intensify phantom echoes based on charge level
- add glitch feedback and collapse overlay for failed rituals
- request whispers for each glyph click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68441a276f488323b961fffbd416ef99