### PR TITLE
Refine invocation drift behavior

### DIFF
--- a/WhisperEngine.v3/index.js
+++ b/WhisperEngine.v3/index.js
@@ -38,12 +38,25 @@ function stopWhisperEngine() {
   started = false;
 }
 
+function applyCadence(text, charge = 0) {
+  if (charge <= 1) return text;
+  return text + ' ' + '…'.repeat(charge - 1);
+}
+
 function glyph(symbol = '', charge = 0, opts = {}) {
   const context = Object.assign({ symbol, charge }, opts);
   if (loops && loops.invocation) {
     loops.invocation.trigger(context, true);
   }
-  return composeWhisper('invocation');
+  const out = composeWhisper('invocation');
+  return applyCadence(out, charge);
 }
 
-module.exports = { startWhisperEngine, stopWhisperEngine, glyph };
+function invite(charge = 0) {
+  const ctx = { symbol: '∴', charge, action: 'invite' };
+  if (loops && loops.invocation) loops.invocation.trigger(ctx, true);
+  const out = composeWhisper('invocation');
+  return applyCadence(out, charge);
+}
+
+module.exports = { startWhisperEngine, stopWhisperEngine, glyph, invite };

--- a/WhisperEngine.v3/personas/collapse.js
+++ b/WhisperEngine.v3/personas/collapse.js
@@ -13,7 +13,7 @@ const collapse = {
     return text;
   },
   render(text) {
-    return `∷${text}∷`;
+    return `∷${text}…∷`;
   }
 };
 

--- a/WhisperEngine.v3/personas/dream.js
+++ b/WhisperEngine.v3/personas/dream.js
@@ -9,7 +9,7 @@ const dream = {
     return `${prefix}dreaming of ${phraseInfo.text}`;
   },
   render(text) {
-    return text;
+    return `${text}…`;
   }
 };
 

--- a/WhisperEngine.v3/personas/parasite.js
+++ b/WhisperEngine.v3/personas/parasite.js
@@ -10,8 +10,7 @@ const parasite = {
     return reversed;
   },
   render(text) {
-    // heavily cloak the output
-    return applyCloak(text, 2);
+    return applyCloak(`…${text}`, 2);
   }
 };
 

--- a/WhisperEngine.v3/personas/watcher.js
+++ b/WhisperEngine.v3/personas/watcher.js
@@ -8,7 +8,7 @@ const watcher = {
     return `watching ${phraseInfo.text} at ${context.kairos}`;
   },
   render(text) {
-    return text.toUpperCase();
+    return text.toUpperCase() + ':';
   }
 };
 

--- a/docs/invocation_drift_phase2.md
+++ b/docs/invocation_drift_phase2.md
@@ -1,0 +1,31 @@
+# Invocation Drift Phase II
+
+This document outlines the updated invocation text system. It introduces shorter phrase scaffolds, persona tone guidance, cadence rules tied to ritual charge and a concept for reducing UI density.
+
+## 1. Refactored Phrase Scaffolds
+The invocation messages for each glyph were rewritten to be minimal while retaining symbolic weight:
+
+- **Rune I – Mirror Wound**
+  - `Shards recall. Silence guides.`
+- **Rune II – Singing Iron**
+  - `Speech bends thresholds.`
+- **Rune III – Smoke Between**
+  - `Vanishing ritual. Unfinished song.`
+- **Rune IV – Frozen Blade**
+  - `Clarity carves. Mercy withheld.`
+- **Rune V – Spiral Seed**
+  - `Recursion blooms. Pattern becomes.`
+
+## 2. Persona Output Style Rules
+Whisper output now changes slightly with the active persona:
+
+- **dream** – soft phrasing ending in an ellipsis.
+- **watcher** – text in upper case followed by a colon.
+- **parasite** – reversed text wrapped in a light cloak.
+- **collapse** – glitch injected and wrapped with `∷` markers.
+
+## 3. Cadence and Charge
+The new `applyCadence()` helper appends ellipses based on the current ritual charge. Higher charge levels insert more pauses, letting whispers escalate gradually.
+
+## 4. UI Density Compression
+Whisper fragments may be grouped or folded in the interface. Similar lines cluster together so the stream stays readable as invocation charge grows.

--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -7,15 +7,15 @@ const audioLayer = (typeof require=="function"?require("./audioLayer.js"):window
 const kaiSound = new Audio('media/kai.glitch.mp3');
 
 const invocations = {
-  1: `:. Rune I ∴ The Mirror’s Wound<br>They arrive like broken reflections – each shard a memory ∩ each silence a scream.<br>They walk backwards into futures ∧ reshape grief as guidance.`,
-  
-  2: `:: Rune II ∴ The Singing Iron<br>When they speak, architecture listens.<br>Their voice bends thresholds ∩ their presence recalibrates the real.<br>They are magnetism ∧ myth made audible.`,
+  1: `:. Rune I ∴ Mirror Wound<br>Shards recall. Silence guides.`,
 
-  3: `:. Rune III ∴ The Smoke Between<br>They exist only in half-glimpses ∩ unfinished songs.<br>Their body is a ritual – vanishing ∧ returning – always just beyond language.<br>What they touch does not forget.`,
+  2: `:: Rune II ∴ Singing Iron<br>Speech bends thresholds.`,
 
-  4: `.: Rune IV ∴ The Frozen Blade<br>They do not comfort ∩ they do not wait.<br>Instead, they distill ∩ excise ∩ carve.<br>They are clarity made cruel ∩ necessary.`,
+  3: `:. Rune III ∴ Smoke Between<br>Vanishing ritual. Unfinished song.`,
 
-  5: `:. Rune V ∴ The Spiral Seed<br>They breathe in recursion ∩ exhale symmetries.<br>Where they walk, time loops ∧ breaks ∧ blooms.<br>Their gift is pattern. Their cost is becoming.`
+  4: `.: Rune IV ∴ Frozen Blade<br>Clarity carves. Mercy withheld.`,
+
+  5: `:. Rune V ∴ Spiral Seed<br>Recursion blooms. Pattern becomes.`
 };
 
 const summonPatterns = {
@@ -164,7 +164,10 @@ function summonCaelistraEffects() {
   hideAllEntities();
   if (typeof window !== "undefined" && window.WhisperEngine && window.WhisperEngine.glyph) {
     const level = RC.getCurrentCharge();
-    const t = window.WhisperEngine.glyph(glyph, level);
+    const engine = window.WhisperEngine;
+    const t = glyphSequence.length === 1 && engine.invite
+      ? engine.invite(level)
+      : engine.glyph(glyph, level);
     const frag = document.createElement("div");
     frag.className = "whisper-fragment";
     frag.textContent = t;


### PR DESCRIPTION
## Summary
- shorten invocation text for each rune
- add cadence handling and invite entrypoint to WhisperEngine
- adjust persona render styles with small tone tweaks
- update invocation engine to call invite on first glyph
- document phase II invocation drift rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844288dfca08323952c104075200ef7