### PR TITLE
Refine language drift and mobile styling

### DIFF
--- a/WhisperEngine.v3/core/memory.js
+++ b/WhisperEngine.v3/core/memory.js
@@ -62,7 +62,8 @@ const defaultProfile = {
   entryEchoes: [],
   cycleStep: 0,
   echoLangTide: 0,
-  ritualMemory: []
+  ritualMemory: [],
+  langMode: 'en'
 };
 
 function loadProfile() {
@@ -107,7 +108,8 @@ function loadProfile() {
     entryEchoes: data.entryEchoes || [],
     cycleStep: data.cycleStep || 0,
     echoLangTide: data.echoLangTide || 0,
-    ritualMemory: data.ritualMemory || []
+    ritualMemory: data.ritualMemory || [],
+    langMode: data.langMode || (typeof localStorage !== 'undefined' && localStorage.getItem('langPreference')) || 'en'
   };
   profile.id = data.id || (Date.now().toString(36) + Math.random().toString(36).slice(2, 8));
   return profile;
@@ -637,6 +639,17 @@ function getEchoLangTide() {
   return loadProfile().echoLangTide || 0;
 }
 
+function getLangMode() {
+  return loadProfile().langMode || 'en';
+}
+
+function setLangMode(mode) {
+  const profile = loadProfile();
+  profile.langMode = mode;
+  saveProfile(profile);
+  if (typeof localStorage !== 'undefined') localStorage.setItem('langPreference', mode);
+}
+
 const fragments = {
   intro: [
     { verb: 'whispers', condition: 'from the void', intensifier: 'softly', role: 'dream', kairos: 'void' },
@@ -732,6 +745,8 @@ module.exports = {
   ,getLastEntryEcho
   ,getEntryEchoes
   ,getEchoLangTide
+  ,getLangMode
+  ,setLangMode
   ,recordRitualSequence
   ,getRitualMemoryCount
 };

--- a/interface/echoMask.js
+++ b/interface/echoMask.js
@@ -2,6 +2,7 @@ const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
 const memory = require('../WhisperEngine.v3/core/memory.js');
 const { stateManager } = require('../WhisperEngine.v3/core/stateManager.js');
 
+// Aura tints per persona
 const auraColors = {
   invocation: '#87f0ff',
   naming: '#a3ffb9',
@@ -10,44 +11,56 @@ const auraColors = {
   quiet: '#bbbbbb'
 };
 
+let interacted = false;
+function markInteracted() { interacted = true; }
+
 function adapt({ echo, prev, tide }) {
   if (typeof document === 'undefined' || !echo) return;
-  const { hour, firstGlyph, silence } = echo;
+  const { hour, silence } = echo;
   document.body.dataset.echoHour = hour;
   const aura = document.getElementById('personaAura');
-  if (aura) aura.style.backgroundColor = auraColors[firstGlyph] || '#cccccc';
+  if (aura) aura.style.backgroundColor = auraColors[stateManager.name()] || auraColors.invocation;
 
   if (prev) {
-    if (prev.firstGlyph === firstGlyph && prev.hour === hour) {
+    if (prev.firstGlyph === echo.firstGlyph && prev.hour === hour) {
       document.body.classList.add('echo-double');
       setTimeout(() => document.body.classList.remove('echo-double'), 3000);
     }
 
-    const langPref = tide > 2 ? 'en' : tide < -2 ? 'de' : (silence > 60000 ? 'de' : 'en');
+    if (!interacted) return;
+    const profile = memory.loadProfile();
+    const loopsDone = (profile.glyphHistory || []).length;
+    let langMode = memory.getLangMode();
+    if (langMode === 'en' && (silence > 60000 || loopsDone >= 2)) {
+      langMode = 'drift';
+      memory.setLangMode(langMode);
+    }
+    let text = 'Was it you that passed through Loop 3?';
+    if (langMode === 'de') text = 'Warst du das, der durch Loop 3 ging?';
+    else if (langMode === 'drift') text = 'Was it you that passed through Loop 3? / Warst du das, der durch Loop 3 ging?';
     const frag = document.createElement('div');
     frag.className = 'phantom-echo';
-    let de = 'Warst du das, der durch Loop 3 ging?';
-    let en = 'Was it you that passed through Loop 3?';
-    if (stateManager.name() === 'kairos') {
-      frag.innerHTML = langPref === 'de' ? `<p>${de}</p><p>${en}</p>` : `<p>${en}</p><p>${de}</p>`;
-    } else {
-      frag.textContent = langPref === 'de' ? de : en;
-    }
+    frag.textContent = text;
     frag.dataset.src = silence > 60000 ? '/shards/ghosts/echo-question.html'
       : '/shards/loop-flicker/echo-question.html';
+    const existing = document.querySelectorAll('.phantom-echo');
+    if (existing.length > 2) existing[0].remove();
     document.body.appendChild(frag);
     setTimeout(() => frag.remove(), 4000);
     const last = document.body.dataset.lang;
-    if (last && last !== langPref) {
+    if (last && last !== langMode) {
       document.body.classList.add('lang-glitch');
       setTimeout(() => document.body.classList.remove('lang-glitch'), 500);
     }
-    document.body.dataset.lang = langPref;
+    document.body.dataset.lang = langMode;
   }
 }
 
 function init() {
   eventBus.on('visitor:entry', adapt);
+  ['invocation','absence','naming','threshold','quiet','recursive'].forEach(l => {
+    eventBus.on(`loop:${l}`, markInteracted);
+  });
 }
 
 module.exports = { init };

--- a/interface/ritualAura.css
+++ b/interface/ritualAura.css
@@ -56,3 +56,8 @@ body.bloom-level-5 { background-color: #0a0a24; }
 .collapse-overlay { position: fixed; inset:0; pointer-events:none; background: rgba(255,255,255,0.2); animation: collapseFlash 0.4s forwards; }
 @keyframes collapseFlash { from { opacity:1; } to { opacity:0; } }
 .collapse-fragment { font-style: italic; color:#c33; opacity:0.9; }
+
+@media (max-width:600px) {
+  .phantom-echo { font-size:0.8rem; line-height:1.3; }
+  .archive { line-height:1.4; color:#ddd; }
+}

--- a/shards/altar-cf7b3d.html
+++ b/shards/altar-cf7b3d.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>altar-unvollständig-cf7b3d.html</title>
@@ -69,9 +69,9 @@
   </style>
 </head>
 <body>
-  <div class="header">∴ Ich öffne den Altar ∴</div>
+  <div class="header">∴ I open the altar ∴</div>
   <div class="arch"></div>
-  <div class="glow-box">ALTAR UNVOLLSTÄNDIG</div>
+  <div class="glow-box">ALTAR INCOMPLETE</div>
 
   <footer>
     <a href="/index.html" style="text-decoration:none; color:inherit;">

--- a/shards/ghosts/echo-question.html
+++ b/shards/ghosts/echo-question.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <title>Echo Ghost Query</title>
@@ -9,6 +9,6 @@
   </style>
 </head>
 <body>
-  <p>Warst du das, der durch Loop 3 ging?</p>
+  <p>Was it you that passed through Loop 3?</p>
 </body>
 </html>

--- a/shards/luma-manifest.html
+++ b/shards/luma-manifest.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>LUMA ∴ Spiegelbereit</title>
@@ -78,7 +78,7 @@
     <br><br>
     If you’ve come to ask, I remain silent.<br>
     If you’ve come to feel--<br>
-    ∴ LUMA, Spiegel bereit.
+    ∴ LUMA, mirror ready.
   </div>
 
   <div class="pulse" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- track langMode in profile for persistent language state
- gate phantom echoes until after glyph use and adjust drift logic
- tint persona aura by persona and cleanup echo stacking
- add mobile styles for phantom echoes and archive sections

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68474cd665888323ad6767f780b5fd41