### PR TITLE
Hotfix for calm initial aura

### DIFF
--- a/css/codex-whisper.css
+++ b/css/codex-whisper.css
@@ -181,13 +181,18 @@ body {
   pointer-events: none;
   transition: background 0.8s ease;
   z-index: -1;
+  background: rgba(24, 32, 48, 0.25);
 }
 
-#personaAura[data-persona='dream'] { background: rgba(0,0,40,0.3); }
-#personaAura[data-persona='watcher'] { background: rgba(40,0,0,0.3); }
-#personaAura[data-persona='archive'] { background: rgba(0,40,0,0.3); }
-#personaAura[data-persona='parasite'] { background: rgba(40,0,40,0.3); }
-#personaAura[data-persona='collapse'] { background: rgba(20,20,20,0.5); }
+#personaAura[data-persona='neutral'] {
+  background: rgba(24, 32, 48, 0.25);
+}
+
+#personaAura[data-persona='dream'] { background: rgba(0, 0, 40, 0.3); }
+#personaAura[data-persona='watcher'] { background: rgba(40, 0, 0, 0.3); }
+#personaAura[data-persona='archive'] { background: rgba(0, 40, 0, 0.3); }
+#personaAura[data-persona='parasite'] { background: rgba(40, 0, 40, 0.3); }
+#personaAura[data-persona='collapse'] { background: rgba(20, 20, 20, 0.3); }
 
 /* Animations */
 @keyframes fadeWhisperIn {
@@ -219,6 +224,15 @@ body {
   .whisper-line {
     font-size: 0.94rem;
     padding: 0.2rem 0.5rem;
+  }
+
+  .whisper-container {
+    background: rgba(15, 25, 35, 0.45);
+  }
+
+  .whisper-line {
+    color: #d8eef9;
+    text-shadow: 0 0 6px #d8eef9aa;
   }
 
   .ritual-label {

--- a/interface/echoMask.js
+++ b/interface/echoMask.js
@@ -4,11 +4,11 @@ const { stateManager } = require('../WhisperEngine.v3/core/stateManager.js');
 
 // Aura tints per persona
 const auraColors = {
-  invocation: '#87f0ff',
-  naming: '#a3ffb9',
-  threshold: '#ffbf81',
-  absence: '#cccccc',
-  quiet: '#bbbbbb'
+  invocation: 'rgba(135, 240, 255, 0.28)',
+  naming: 'rgba(163, 255, 185, 0.28)',
+  threshold: 'rgba(255, 191, 129, 0.28)',
+  absence: 'rgba(204, 204, 204, 0.28)',
+  quiet: 'rgba(187, 187, 187, 0.28)'
 };
 
 let interacted = false;
@@ -19,7 +19,9 @@ function adapt({ echo, prev, tide }) {
   const { hour, silence } = echo;
   document.body.dataset.echoHour = hour;
   const aura = document.getElementById('personaAura');
-  if (aura) aura.style.backgroundColor = auraColors[stateManager.name()] || auraColors.invocation;
+  if (aura && interacted) {
+    aura.style.backgroundColor = auraColors[stateManager.name()] || auraColors.invocation;
+  }
 
   if (prev) {
     if (prev.firstGlyph === echo.firstGlyph && prev.hour === hour) {

--- a/interface/personaAura.js
+++ b/interface/personaAura.js
@@ -1,24 +1,38 @@
 const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
 let current = '';
 let aura;
+let activated = false;
 
 function update(name) {
   current = name;
-  if (!aura) return console.log(`[personaAura] ${name}`);
-  aura.setAttribute('data-persona', name);
-  aura.textContent = name;
+  if (!aura || !activated) return;
+  requestAnimationFrame(() => {
+    aura.setAttribute('data-persona', name);
+    aura.textContent = name;
+  });
+}
+
+function activate() {
+  if (!activated) {
+    activated = true;
+    if (current) update(current);
+  }
 }
 
 function init() {
   aura = typeof document !== 'undefined' ? document.getElementById('personaAura') : null;
+  if (aura) aura.setAttribute('data-persona', 'neutral');
   eventBus.on('persona:shift', update);
+  ['invocation','absence','naming','threshold','quiet','recursive'].forEach(l => {
+    eventBus.on(`loop:${l}`, activate);
+  });
   eventBus.on('presence', () => {
-    if (!aura) return console.log('[personaAura] presence');
+    if (!aura || !activated) return;
     aura.classList.add('presence', 'pulse');
     setTimeout(() => aura.classList.remove('presence', 'pulse'), 2000);
   });
   eventBus.on('cloak:max', () => {
-    if (!aura) return console.log('[personaAura] cloak-max');
+    if (!aura || !activated) return;
     aura.classList.add('cloak-max');
     setTimeout(() => aura.classList.remove('cloak-max'), 500);
   });


### PR DESCRIPTION
## Summary
- soften persona aura and add neutral default state
- gate personaAura updates until user interacts
- reduce echoMask aura opacity and delay echo fragments
- tweak mobile contrast for whisper text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68475e08f2308323aa333dbd440bb46d