### PR TITLE
Adjust overlay triggers

### DIFF
--- a/interface/echoMask.js
+++ b/interface/echoMask.js
@@ -46,7 +46,10 @@ function adapt({ echo, prev, tide }) {
     frag.dataset.src = silence > 60000 ? '/shards/ghosts/echo-question.html'
       : '/shards/loop-flicker/echo-question.html';
     const existing = document.querySelectorAll('.phantom-echo');
-    if (existing.length > 2) existing[0].remove();
+    if (existing.length >= 3) {
+      existing[0].classList.add('fade-out');
+      setTimeout(() => existing[0].remove(), 300);
+    }
     document.body.appendChild(frag);
     setTimeout(() => frag.remove(), 4000);
     const last = document.body.dataset.lang;

--- a/interface/personaAura.js
+++ b/interface/personaAura.js
@@ -26,6 +26,7 @@ function init() {
   ['invocation','absence','naming','threshold','quiet','recursive'].forEach(l => {
     eventBus.on(`loop:${l}`, activate);
   });
+  setTimeout(() => { if (!activated) activate(); }, 5000);
   eventBus.on('presence', () => {
     if (!aura || !activated) return;
     aura.classList.add('presence', 'pulse');

--- a/interface/ritualAura.css
+++ b/interface/ritualAura.css
@@ -52,6 +52,7 @@ body.bloom-level-5 { background-color: #0a0a24; }
 .phantom-echo.intensity-3 { opacity: 0.8; }
 .phantom-echo.intensity-4 { opacity: 1; font-weight: bold; }
 .phantom-echo.intensity-5 { opacity: 1; font-weight: bold; text-shadow: 0 0 6px #f9f; }
+.phantom-echo.fade-out { opacity: 0 !important; transition: opacity 0.3s ease; }
 @keyframes echoFade { from { opacity:0.8; } to { opacity:0; transform: translate(-50%,-20px);} }
 .collapse-overlay { position: fixed; inset:0; pointer-events:none; background: rgba(255,255,255,0.2); animation: collapseFlash 0.4s forwards; }
 @keyframes collapseFlash { from { opacity:1; } to { opacity:0; } }

--- a/js/bloomController.js
+++ b/js/bloomController.js
@@ -1,7 +1,14 @@
 let level = 0;
+let glyphCount = 0;
+let enabled = false;
+
+function registerGlyph() {
+  glyphCount++;
+  if (glyphCount >= 2) enabled = true;
+}
 
 function setLevel(l) {
-  if (typeof document === 'undefined') return;
+  if (typeof document === 'undefined' || !enabled) return;
   const body = document.body;
   body.classList.remove(`bloom-level-${level}`);
   level = l;
@@ -30,6 +37,6 @@ function startGlyphDrift() {
   reset();
 }
 
-const api = { setLevel, entityBloom, startGlyphDrift };
+const api = { setLevel, entityBloom, startGlyphDrift, registerGlyph };
 if (typeof module !== 'undefined' && module.exports) module.exports = api;
 if (typeof window !== 'undefined') window.bloomController = api;

--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -201,6 +201,7 @@ function handleGlyphClick(glyph) {
   if (memory && memory.recordGlyphDrift) memory.recordGlyphDrift(lastGlyph, glyph);
   const drifted = memory && memory.getDriftVariant ? memory.getDriftVariant(glyph, lastGlyph) : glyph;
   glyphSequence.push(glyph);
+  if (bloomController && bloomController.registerGlyph) bloomController.registerGlyph();
   if (glyphSequence.length > 5) glyphSequence.shift();
   logRitual(glyph);
 


### PR DESCRIPTION
## Summary
- limit phantom echo stack to three elements and fade extras
- ensure aura activation after five seconds if no loops are triggered
- delay bloom level changes until at least two glyphs have been entered
- rebuild bundle

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684760df41cc8323a4fc03fd8542a7cc