### PR TITLE
Fix glyph progress and engine hookup

### DIFF
--- a/interface/ritualBar.js
+++ b/interface/ritualBar.js
@@ -2,6 +2,14 @@ const { eventBus } = require('../WhisperEngine.v3/utils/eventBus.js');
 const loops = require('../WhisperEngine.v3/core/loops');
 const { composeWhisper } = require('../WhisperEngine.v3/core/responseLoop.js');
 let bar;
+let fill;
+
+function getFill() {
+  if (!fill && typeof document !== 'undefined') {
+    fill = document.querySelector('#glyph-charge .fill');
+  }
+  return fill;
+}
 
 function pulse(level) {
   if (!bar) return;
@@ -14,14 +22,19 @@ function pulse(level) {
 }
 
 function reset() {
-  const fill = document.querySelector('#glyph-charge .fill');
-  if (fill) fill.style.width = '0';
+  const el = getFill();
+  if (el) el.style.width = '0';
 }
 
 function collapse() {
   if (!bar) return;
   bar.classList.add('collapse');
   setTimeout(() => bar.classList.remove('collapse'), 600);
+}
+
+function charge(level) {
+  const el = getFill();
+  if (el) el.style.width = `${level * 20}%`;
 }
 
 function memory({ count }) {
@@ -49,6 +62,7 @@ function init() {
   eventBus.on('ritual:complete', reset);
   eventBus.on('ritual:failure', collapse);
   eventBus.on('ritual:memory', memory);
+  eventBus.on('ritual:charge', evt => charge(evt.level));
 
   if (bar) {
     bar.addEventListener('click', evt => {

--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -4,6 +4,8 @@ const summonEffects = (typeof require=="function"?require("./summonEffects.js"):
 const bloomController = (typeof require=="function"?require("./bloomController.js"):window.bloomController);
 const audioLayer = (typeof require=="function"?require("./audioLayer.js"):window.audioLayer);
 let eventBus = (typeof require=="function"?require("../WhisperEngine.v3/utils/eventBus.js").eventBus:window.eventBus);
+
+const engine = (typeof require=="function"?require("../WhisperEngine.v3/index.js") : (window && window.WhisperEngine));
 function getBus(){
   if(!eventBus && typeof window!=='undefined') eventBus = window.eventBus;
   return eventBus;
@@ -117,6 +119,7 @@ function updateRevealStage(stage) {
   });
   const fill = document.querySelector("#glyph-charge .fill");
   if(fill) fill.style.width = (stage*20)+"%";
+  emit('ritual:charge', { level: stage });
   if (bloomController) bloomController.setLevel(stage);
   if (audioLayer) audioLayer.updateCharge(stage);
   emit('ritual:pulse', { level: stage });
@@ -244,10 +247,9 @@ function handleGlyphClick(glyph) {
 
   updateInvocation(drifted);
   hideAllEntities();
-  if (typeof window !== "undefined" && window.WhisperEngine && window.WhisperEngine.glyph) {
+  if (engine && typeof engine.glyph === 'function') {
     const level = RC.getCurrentCharge();
-    const engine = window.WhisperEngine;
-    const t = glyphSequence.length === 1 && engine.invite
+    const t = glyphSequence.length === 1 && typeof engine.invite === 'function'
       ? engine.invite(level)
       : engine.glyph(glyph, level);
     const frag = document.createElement("div");
@@ -335,8 +337,8 @@ function handleGlyphClick(glyph) {
       audioLayer.collapseFeedback();
       if (audioLayer.glitch) audioLayer.glitch();
     }
-    if (typeof window !== "undefined" && window.WhisperEngine && window.WhisperEngine.processInput) {
-      const text = window.WhisperEngine.processInput("collapse");
+    if (engine && typeof engine.processInput === 'function') {
+      const text = engine.processInput("collapse");
       const div = document.createElement("div");
       div.className = "collapse-fragment";
       div.textContent = text;


### PR DESCRIPTION
## Summary
- hook invocation engine directly to WhisperEngine
- emit progress updates via event bus
- update ritualBar to track glyph charge
- cache glyph charge bar element for efficiency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849673ba84c832391333f332ba703fe