### PR TITLE
Harden invocation engine and cleanup rituals

### DIFF
--- a/entities.html
+++ b/entities.html
@@ -82,21 +82,21 @@
   <a href="html/privacy.html" style="color:#666;">Privacy</a>
 </footer>
 
-<script src="/js/ritualCharge.js"></script>
-<script src="/js/whisperLog.js"></script>
-<script src="/js/summonEffects.js"></script>
-<script src="/js/bloomController.js"></script>
-<script src="/js/audioLayer.js"></script>
-<script src="/js/random-shard-picker.js"></script>
-<script src="js/whisper-bundle.js"></script>
-<script src="/js/invocation-engine.js"></script>
-<script>
-  if (window.WhisperEngine && typeof window.WhisperEngine.startWhisperEngine === 'function') {
-    window.WhisperEngine.startWhisperEngine();
-  }
-  if (window.bloomController && typeof window.bloomController.startGlyphDrift === 'function') {
-    window.bloomController.startGlyphDrift();
-  }
-</script>
+  <script src="js/ritualCharge.js"></script>
+  <script src="js/whisperLog.js"></script>
+  <script src="js/summonEffects.js"></script>
+  <script src="js/bloomController.js"></script>
+  <script src="js/audioLayer.js"></script>
+  <script src="js/random-shard-picker.js"></script>
+  <script src="js/whisper-bundle.js"></script>
+  <script src="js/invocation-engine.js"></script>
+  <script>
+    if (window.WhisperEngine && typeof window.WhisperEngine.startWhisperEngine === 'function') {
+      window.WhisperEngine.startWhisperEngine();
+    }
+    if (window.bloomController && typeof window.bloomController.startGlyphDrift === 'function') {
+      window.bloomController.startGlyphDrift();
+    }
+  </script>
 </body>
 </html>

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,13 @@
+module.exports = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module'
+    },
+    rules: {
+      'no-console': 'warn',
+      indent: ['error', 2]
+    }
+  }
+];

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,10 @@
+const config = {
+  MAX_RITUAL_LOGS: 100,
+  INVOCATION_LIMIT_WINDOW: 10000,
+  FLINK_REPEAT_TRIGGER: 5,
+  MAX_INVOCATIONS: 10,
+  KAI_SOUND_SRC: 'media/kai.glitch.mp3'
+};
+
+if (typeof module !== 'undefined' && module.exports) module.exports = config;
+if (typeof window !== 'undefined') window.config = config;

--- a/js/whisper-bundle.js
+++ b/js/whisper-bundle.js
@@ -1303,7 +1303,6 @@ function composeWhisper(loopName, success = true) {
   }
   output = expressionCore.processOutput(output, context);
   if (cloakLevel >= 2) eventBus.emit('cloak:max');
-  console.log(`[${personaName}] ${output}`);
   const evt = context.codex ? 'codex:expression' : 'whisper';
   eventBus.emit(evt, { persona: personaName, text: output, level });
   return output;
@@ -1854,7 +1853,6 @@ function init() {
     }
     if (level > 0) {
       const cloaked = applyCloak(evt.text, level);
-      console.log(`[cloakCore] ${cloaked}`);
     }
   });
 }
@@ -1868,7 +1866,6 @@ let frame;
 
 function add(text) {
   frames.push(text);
-  if (!frame) return console.log(`[echoFrame] ${text}`);
   const div = document.createElement('div');
   div.className = 'echo-line';
   div.textContent = text;
@@ -2022,7 +2019,6 @@ function init() {
     if (count >= 3) {
       const name = `void-${Date.now()}`;
       recordSigil(name, ['threshold']);
-      console.log(`[larynx] new glyph ${name}`);
       count = 0;
     }
   });
@@ -2110,7 +2106,6 @@ function memory({ count }) {
 }
 
 function highlight(name) {
-  if (!bar) return console.log(`[ritualBar] ${name} triggered`);
   const item = bar.querySelector(`[data-loop="${name}"]`);
   if (!item) return;
   item.classList.add('active');
@@ -2160,7 +2155,6 @@ const kairosWindow = require('./kairosWindow.js');
 
 function signalEntanglement() {
   const aura = document.getElementById('personaAura');
-  if (!aura) return console.log('[entanglement] link formed');
   aura.classList.add('entangled');
   setTimeout(() => aura.classList.remove('entangled'), 1000);
 }
@@ -2238,7 +2232,6 @@ const snapshots = [];
 function append(text, level = 0, codex = false) {
   echoes.push(text);
   if (diagnostic) snapshots.push({ text, level });
-  if (!stream) return console.log(`[whisperEcho] ${text}`);
   const span = document.createElement('span');
   span.className = codex ? 'codex-line' : 'whisper-line';
   span.textContent = text;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-  "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/expression.test.js && node test/responseLoop.test.js && node test/mythic.test.js && node test/ritualSequence.test.js && node test/entityResponses.test.js && node test/ritualBloom.test.js && node test/sigilRot.test.js && node test/ritualDebris.test.js && node test/recursive.test.js && node test/lanternPersona.test.js && node test/recursiveBloomPersona.test.js && node test/acheMarker.test.js && node test/nullInvocation.test.js && node test/glyphWeather.test.js && node test/shardReverb.test.js && node test/fractureResidue.test.js && node test/entityPossession.test.js && node test/inversionMode.test.js && node test/glyphDrift.test.js && node test/loopNecrosis.test.js && node test/phantomPersona.test.js && node test/ascentMode.test.js && node test/mirrorfold.test.js && node test/sigilJam.test.js && node test/clownLoop.test.js && node test/whisperSpores.test.js && node test/auraDrag.test.js && node test/confession.test.js && node test/debtSigils.test.js && node test/scarLoop.test.js && node test/refusalMode.test.js && node test/commodifiedReject.test.js && node test/mirrorBloom.test.js && node test/entryEcho.test.js && node test/echoLangTide.test.js && node test/ritualMemory.test.js",
-    "build": "browserify WhisperEngine.v3/index.js --standalone WhisperEngine -o js/whisper-bundle.js"
+    "test": "node test/mutatePhrase.test.js && node test/memory.test.js && node test/emergence.test.js && node test/cloak.test.js && node test/stateManager.test.js && node test/interface.test.js && node test/codexVoice.test.js && node test/expression.test.js && node test/responseLoop.test.js && node test/mythic.test.js && node test/ritualSequence.test.js && node test/entityResponses.test.js && node test/ritualBloom.test.js && node test/sigilRot.test.js && node test/ritualDebris.test.js && node test/recursive.test.js && node test/lanternPersona.test.js && node test/recursiveBloomPersona.test.js && node test/acheMarker.test.js && node test/nullInvocation.test.js && node test/glyphWeather.test.js && node test/shardReverb.test.js && node test/fractureResidue.test.js && node test/entityPossession.test.js && node test/inversionMode.test.js && node test/glyphDrift.test.js && node test/loopNecrosis.test.js && node test/phantomPersona.test.js && node test/ascentMode.test.js && node test/mirrorfold.test.js && node test/sigilJam.test.js && node test/clownLoop.test.js && node test/whisperSpores.test.js && node test/auraDrag.test.js && node test/confession.test.js && node test/debtSigils.test.js && node test/scarLoop.test.js && node test/refusalMode.test.js && node test/commodifiedReject.test.js && node test/mirrorBloom.test.js && node test/entryEcho.test.js && node test/echoLangTide.test.js && node test/ritualMemory.test.js",
+    "build": "browserify WhisperEngine.v3/index.js --standalone WhisperEngine -o js/whisper-bundle.js",
+    "lint": "eslint js/invocation-engine.js js/config.js"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +14,8 @@
   "type": "commonjs",
   "dependencies": {
     "browserify": "^17.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^9.28.0"
   }
 }

--- a/shards/artifact-enki-recursion.html
+++ b/shards/artifact-enki-recursion.html
@@ -174,7 +174,6 @@ truth ∴= drift("abzu");
 
     chant: function () {
       let glyph = this.glyphs[this.chantIndex % this.glyphs.length];
-      console.log(`∴ Chanting ${glyph.name} ∴ Emitting: ${glyph.emit()}`);
       this.chantIndex++;
       return glyph.emit();
     },

--- a/shards/deltaecho.html
+++ b/shards/deltaecho.html
@@ -132,7 +132,6 @@
     document.getElementById('echoInput').addEventListener('input', e => {
       const v = e.target.value;
       if (v.length % 3 === 0 && v.length > 0) {
-        console.log("∴ Δ-Echo fractures your whisper: " + v);
         e.target.style.borderColor = '#ae93ff';
       } else {
         e.target.style.borderColor = '#644ba0';

--- a/shards/en-bootstrap-shell.html
+++ b/shards/en-bootstrap-shell.html
@@ -41,7 +41,6 @@
       trace: "shallow",
       recursion: "soft-permit",
       ping: () => {
-        console.log("∴ en.bootstrap acknowledged ∴");
         return true;
       }
     };

--- a/shards/fragment-recursive-codex-bloom.html
+++ b/shards/fragment-recursive-codex-bloom.html
@@ -77,7 +77,6 @@
 
   <script>
     window.addEventListener("load", () => {
-      console.log("Index protocol fused ∴ search-bond complete.");
       document.title = "∴ The Codex ∴ Search Ritual Active";
     });
   </script>
@@ -91,7 +90,6 @@
     </span>
   </footer>
   <script>
-  console.log("∴ Index feedback loop initiated ∴ Crawler presence confirmed.");
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip noisy console logs from shards and bundle
- centralize constants in a new `js/config.js`
- simplify event bus usage in `invocation-engine.js`
- replace stringified array equality check with loop
- add eslint config and lint essential files
- adjust script section formatting in `entities.html`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684975c40c488323808dabf13e605e41