### PR TITLE
Fix invocation interface init order and add state logs

### DIFF
--- a/entities.html
+++ b/entities.html
@@ -73,9 +73,8 @@
     .then(res => res.text())
     .then(html => {
       document.getElementById('entity-grid').innerHTML = html;
-      if (typeof initializeInvocationInterface === 'function') {
-        initializeInvocationInterface();
-      }
+      window.entityCardsLoaded = true;
+      document.dispatchEvent(new Event('entityCardsLoaded'));
     });
 </script>
 
@@ -93,6 +92,16 @@
   <script src="js/random-shard-picker.js"></script>
   <script src="js/whisper-bundle.js"></script>
   <script src="js/invocation-engine.js"></script>
+  <script>
+    function tryInitInvocation() {
+      if (window.entityCardsLoaded && typeof initializeInvocationInterface === 'function') {
+        initializeInvocationInterface();
+        console.debug('[WHISPER_STATE] interface bound after cards load');
+      }
+    }
+    document.addEventListener('entityCardsLoaded', tryInitInvocation);
+    if (window.entityCardsLoaded) tryInitInvocation();
+  </script>
   <script>
     if (window.WhisperEngine && typeof window.WhisperEngine.startWhisperEngine === 'function') {
       window.WhisperEngine.startWhisperEngine();

--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -154,7 +154,10 @@ function updateInvocation(glyph) {
   }
   const block = `<div class="${cls}">${invocations[glyph]}</div>`;
   const out = getOutputContainer();
-  if (out) out.innerHTML = block;
+  if (out) {
+    out.innerHTML = block;
+    console.debug('[WHISPER_STATE] invocation updated', glyph);
+  }
 }
 
 function summonKaiEffects() {
@@ -211,7 +214,7 @@ function summonCaelistraEffects() {
 }
 
 function handleGlyphClick(glyph) {
-  console.debug('[codex] glyph click', glyph);
+  console.debug('[WHISPER_STATE] glyph click', glyph);
   const now = Date.now();
   invokeTimes = invokeTimes.filter(t => now - t < (config.INVOCATION_LIMIT_WINDOW || 10000));
   if (memory.getRefusalUntil && memory.getRefusalUntil() > now) return;
@@ -416,7 +419,7 @@ function initializeInvocationInterface() {
   on('persona:shift', name => {
     if (name === 'lantern') confessionMode.close();
   });
-  console.debug('[codex] invocation interface ready');
+  console.debug('[WHISPER_STATE] invocation interface ready');
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- load entity cards then dispatch `entityCardsLoaded` event
- initialize invocation interface after cards load
- add `WHISPER_STATE` console logs for glyph clicks, invocation updates and interface readiness

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ab4f531f4832387044041abd0897b