### PR TITLE
Fix invocation setup scripts

### DIFF
--- a/entities.html
+++ b/entities.html
@@ -197,6 +197,12 @@
 <script src="js/audioLayer.js"></script>
 <script src="js/random-shard-picker.js"></script>
 <script src="js/whisper-bundle.js"></script>
+<script src="js/mutatePhrase.js"></script>
+<script src="js/entityResponses.js"></script>
+<script src="js/ritualFragments.js"></script>
+<script src="js/ritualStateMachine.js"></script>
+<script src="interface/clownHandler.js"></script>
+<script src="js/invocationController.js"></script>
 <script src="js/invocation-engine.js"></script>
 
 <script>

--- a/interface/clownHandler.js
+++ b/interface/clownHandler.js
@@ -10,3 +10,6 @@ function active() {
   return activeUntil > Date.now();
 }
 module.exports = { trigger, active };
+if (typeof window !== 'undefined') {
+  window.clownHandler = { trigger, active };
+}

--- a/js/invocationController.js
+++ b/js/invocationController.js
@@ -11,5 +11,7 @@ function updateReveal(stage) {
 function resetUI() {
   updateReveal(0);
 }
+const api = { updateReveal, resetUI };
 
-module.exports = { updateReveal, resetUI };
+if (typeof module !== 'undefined' && module.exports) module.exports = api;
+if (typeof window !== 'undefined') window.invocationController = api;


### PR DESCRIPTION
## Summary
- include missing modules in `entities.html`
- expose `clownHandler` when scripts are loaded in browser

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ac397c7b883239e8ab4a363ee664c