### PR TITLE
Expose entity helpers globally

### DIFF
--- a/entities.html
+++ b/entities.html
@@ -197,14 +197,12 @@
 <script src="js/audioLayer.js"></script>
 <script src="js/random-shard-picker.js"></script>
 <script src="js/whisper-bundle.js"></script>
-<script src="js/invocationController.js"></script>
-<script src="js/invocation-engine.js"></script>
 <script src="js/mutatePhrase.js"></script>
 <script src="js/entityResponses.js"></script>
+<script src="js/invocationController.js"></script>
 <script src="js/ritualFragments.js"></script>
 <script src="js/ritualStateMachine.js"></script>
 <script src="interface/clownHandler.js"></script>
-<script src="js/invocationController.js"></script>
 <script src="js/invocation-engine.js"></script>
 
 <script>

--- a/js/entityResponses.js
+++ b/js/entityResponses.js
@@ -62,3 +62,7 @@ function entityRespondFragment(entityName, userRoles = [], loopMemory = {}) {
 }
 
 module.exports = { entityRespondFragment };
+
+if (typeof window !== 'undefined') {
+  window.entityRespondFragment = entityRespondFragment;
+}

--- a/js/mutatePhrase.js
+++ b/js/mutatePhrase.js
@@ -36,3 +36,9 @@ function mutatePhraseWithLevel(input) {
 }
 
 module.exports = { mutatePhrase, mutatePhraseWithLevel, setSynonymDrift };
+
+if (typeof window !== 'undefined') {
+  window.mutatePhrase = mutatePhrase;
+  window.mutatePhraseWithLevel = mutatePhraseWithLevel;
+  window.setSynonymDrift = setSynonymDrift;
+}


### PR DESCRIPTION
## Summary
- expose mutatePhrase functions as globals if window exists
- expose entityRespondFragment globally as well
- load mutatePhrase & entityResponses before invocation-engine in Entities page

## Testing
- `npm test`
- ❌ `npx playwright install chromium` *(fails: Download failed - 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ada705d7c8323b5b4b288e65af646