### PR TITLE
Fix ritual bar not resetting after entity matches

### DIFF
--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -122,8 +122,8 @@ function summonVektorikonEffects() {
   document.body.classList.add('vektorikon-distort');
   setTimeout(() => document.body.classList.remove('vektorikon-distort'), 1500);
 
-staticLoop.currentTime = 0;
-staticLoop.play();
+  staticLoop.currentTime = 0;
+  staticLoop.play();
 
   if (!invocationEl) return;
   const glyphEcho = `
@@ -173,6 +173,7 @@ function handleGlyphClick(glyph) {
       if (summon.onSummon) summon.onSummon();
       matched = true;
       glyphSequence = []; // 💥 clear sequence after valid match
+      updateRitualProgress(0);
       break;
     }
   }
@@ -191,6 +192,7 @@ function handleGlyphClick(glyph) {
     if (invocationEl) invocationEl.innerHTML = summonPatterns.flink.message;
     matched = true;
     glyphSequence = [];
+    updateRitualProgress(0);
   }
 
   // 🧼 If no match and sequence is full, do redirect
@@ -199,6 +201,7 @@ function handleGlyphClick(glyph) {
     setTimeout(() => {
       redirectToRandomShard();
       glyphSequence = [];
+      updateRitualProgress(0);
       redirecting = false;
     }, 1000);
   }


### PR DESCRIPTION
## Summary
- reset ritual progress to 0 when a pattern matches
- reset ritual bar after Fl!nk summon or redirect
- align indentation for Vektorikon audio lines

## Testing
- `npm exec eslint js/invocation-engine.js`
- `npm test` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d4646bc83238530d4245b968b75