### PR TITLE
Add glyph ritual diagnostics

### DIFF
--- a/entities.html
+++ b/entities.html
@@ -63,6 +63,7 @@
   <a href="html/privacy.html" style="color:#666;">Privacy</a>
 </footer>
 
+<script src="/js/ritual-diagnostics.js"></script>
 <script src="/js/invocation-engine.js" defer></script>
 <script src="/js/random-shard-picker.js"></script>
 </body>

--- a/js/invocation-engine.js
+++ b/js/invocation-engine.js
@@ -247,8 +247,11 @@ function handleGlyphClick(glyph) {
     glyphSequence = [];
   }
 
-  // 🧼 If no match and sequence is full, do redirect
+  // 🧼 If no match and sequence is full, whisper diagnostics then redirect
   if (glyphSequence.length === 5 && !matched && !redirecting) {
+    if (window.ritualDiagnostics && ritualDiagnostics.feedback) {
+      ritualDiagnostics.feedback(glyphSequence, summonPatterns, invocationEl);
+    }
     redirecting = true;
     setTimeout(() => {
       redirectToRandomShard();

--- a/js/ritual-diagnostics.js
+++ b/js/ritual-diagnostics.js
@@ -1,0 +1,31 @@
+(function() {
+  function diagnose(sequence, patterns) {
+    var best = { name: null, score: 0 };
+    for (var key in patterns) {
+      var pat = patterns[key].pattern;
+      if (!pat) continue;
+      var score = 0;
+      for (var i = 0; i < sequence.length; i++) {
+        if (sequence[i] === pat[i]) score++;
+      }
+      if (score > best.score) {
+        best = { name: key, score: score };
+      }
+    }
+    return best.score ? best : null;
+  }
+
+  function feedback(sequence, patterns, outputEl) {
+    var result = diagnose(sequence, patterns);
+    if (!result || !outputEl) return;
+    outputEl.innerHTML =
+      '<div class="invocation-block diagnosis">' +
+      result.score + '/5 glyphs resonate with ' + result.name + '.<br>' +
+      'The ritual flickers but no entity answers.' +
+      '</div>';
+  }
+
+  var api = { feedback: feedback };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (typeof window !== 'undefined') window.ritualDiagnostics = api;
+})();

--- a/style.css
+++ b/style.css
@@ -580,3 +580,7 @@ body::before {
   margin-top: 4px;
 }
 
+.diagnosis {
+  color: #ffb3ec;
+  border-color: #ffb3ec;
+}


### PR DESCRIPTION
## Summary
- create `ritual-diagnostics.js` to analyze failed glyph sequences
- surface diagnostic feedback before redirecting to random shard
- style diagnostic blocks
- include diagnostics script on entities page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531ee9e61c8323a54337809749b73d