### PR TITLE
Safer storage access, prevent duplicate analytics events, and update header/assets/copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,40 @@
 (function () {
+  function getStorage(type) {
+    try {
+      return window[type];
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeGetStorageItem(storage, key) {
+    try {
+      return storage ? storage.getItem(key) : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeSetStorageItem(storage, key, value) {
+    try {
+      if (!storage) return false;
+      storage.setItem(key, value);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function safeRemoveStorageItem(storage, key) {
+    try {
+      if (!storage) return false;
+      storage.removeItem(key);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   const CONFIG = {
     requiredFields: ["lage", "bplan", "typ", "nutzung"],
     tieBreakerOrder: [
@@ -803,6 +839,7 @@ return topThree.map((item) => clipWords(item, 22));
 
     const touched = new Set();
     let lastRenderedScore = 50;
+    let toolCompletedSentInMemory = false;
     const toolCompletedSessionKey = "gc_tool_completed_sent";
 
     const setHidden = (el, isHidden) => {
@@ -909,9 +946,10 @@ return topThree.map((item) => clipWords(item, 22));
 
       if (
         requiredComplete(state) &&
-        window.localStorage.getItem("gc_consent") === "granted" &&
+        safeGetStorageItem(getStorage("localStorage"), "gc_consent") === "granted" &&
         typeof window.gtag === "function" &&
-        !window.sessionStorage.getItem(toolCompletedSessionKey)
+        !toolCompletedSentInMemory &&
+        !safeGetStorageItem(getStorage("sessionStorage"), toolCompletedSessionKey)
       ) {
         window.gtag("event", "tool_completed", {
           value: result.score,
@@ -919,7 +957,8 @@ return topThree.map((item) => clipWords(item, 22));
           ampel: result.ampelText,
           confidence: result.confidence
         });
-        window.sessionStorage.setItem(toolCompletedSessionKey, "1");
+        toolCompletedSentInMemory = true;
+        safeSetStorageItem(getStorage("sessionStorage"), toolCompletedSessionKey, "1");
       }
     };
 
@@ -1008,8 +1047,9 @@ return topThree.map((item) => clipWords(item, 22));
       resetBtn.addEventListener("click", () => {
         form.reset();
         touched.clear();
-        window.sessionStorage.removeItem(toolCompletedSessionKey);
-        if (window.localStorage.getItem("gc_consent") === "granted" && typeof window.gtag === "function") {
+        toolCompletedSentInMemory = false;
+        safeRemoveStorageItem(getStorage("sessionStorage"), toolCompletedSessionKey);
+        if (safeGetStorageItem(getStorage("localStorage"), "gc_consent") === "granted" && typeof window.gtag === "function") {
           window.gtag("event", "tool_reset");
         }
         closeAllInfoPanels();

--- a/consent.js
+++ b/consent.js
@@ -7,8 +7,34 @@
   // Referenz für sauberes removeEventListener
   var keydownHandler = null;
 
+  function getStorage(type) {
+    try {
+      return window[type];
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeGetStorageItem(storage, key) {
+    try {
+      return storage ? storage.getItem(key) : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeSetStorageItem(storage, key, value) {
+    try {
+      if (!storage) return false;
+      storage.setItem(key, value);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   function getConsent() {
-    return window.localStorage.getItem(CONSENT_KEY);
+    return safeGetStorageItem(getStorage("localStorage"), CONSENT_KEY);
   }
 
   function hasConsent() {
@@ -61,15 +87,16 @@
   }
 
   function setConsent(value) {
-    window.localStorage.setItem(CONSENT_KEY, value);
-    window.localStorage.setItem(CONSENT_VERSION_KEY, CONSENT_VERSION);
+    var storage = getStorage("localStorage");
+    safeSetStorageItem(storage, CONSENT_KEY, value);
+    safeSetStorageItem(storage, CONSENT_VERSION_KEY, CONSENT_VERSION);
 
     if (value === "granted") loadGa();
     removeBanner();
   }
 
   function shouldAskAgain() {
-    var v = window.localStorage.getItem(CONSENT_VERSION_KEY);
+    var v = safeGetStorageItem(getStorage("localStorage"), CONSENT_VERSION_KEY);
     return v !== CONSENT_VERSION;
   }
 
@@ -91,8 +118,7 @@
     var banner = document.createElement("div");
     banner.id = "gc-consent-banner";
     banner.className = "gc-consent-banner";
-    banner.setAttribute("role", "dialog");
-    banner.setAttribute("aria-modal", "true");
+    banner.setAttribute("role", "region");
     banner.setAttribute("aria-labelledby", "gc-consent-title");
     banner.setAttribute("aria-describedby", "gc-consent-desc");
 

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -15,7 +15,7 @@
   <meta name="robots" content="noindex,follow" />
   <link rel="canonical" href="https://grundstueckcheck.de/datenschutz.html" />
 
-  <link rel="stylesheet" href="styles.css?v=1.4" />
+  <link rel="stylesheet" href="/styles.css?v=2.1.1" />
 </head>
 
 <body>
@@ -57,7 +57,7 @@
           </button>
       
           <nav class="site-header__nav" id="site-header-nav" aria-label="Hauptnavigation">
-            <a class="site-header__link" href="/" data-nav>Home</a>
+            <a class="site-header__link" href="/" data-nav>Grundstücks-Check</a>
       
             <div class="site-header__tools">
               <button
@@ -72,14 +72,14 @@
               </button>
       
               <div class="site-header__tools-panel" id="site-header-tools-panel" aria-label="Tools Navigation">
+                <a class="site-header__tools-item" href="/" data-nav>
+                  <span class="site-header__tools-title">Grundstücks-Check</span>
+                  <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
+                </a>
+      
                 <a class="site-header__tools-item" href="/mieten-oder-kaufen-rechner.html" data-nav>
                   <span class="site-header__tools-title">Mieten oder Kaufen</span>
                   <span class="site-header__tools-sub">Finanzielle Einordnung in wenigen Klicks</span>
-                </a>
-      
-                <a class="site-header__tools-item" href="/" data-nav>
-                  <span class="site-header__tools-title">Wohnen oder Bauen erlaubt?</span>
-                  <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
                 </a>
               </div>
             </div>
@@ -243,7 +243,7 @@
 
   <footer class="container page-footer">
     <nav aria-label="Rechtliche Seiten">
-      <a href="/">Startseite</a>
+      <a href="/">Grundstücks-Check</a>
       <a href="/impressum.html">Impressum</a>
       <a href="/datenschutz.html">Datenschutz</a>
     </nav>

--- a/impressum.html
+++ b/impressum.html
@@ -20,7 +20,7 @@
     <meta property="og:title" content="Impressum – Grundstücks-Check" />
     <meta property="og:description" content="Rechtliche Angaben und Anbieterkennzeichnung von grundstueckcheck.de." />
 
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="/styles.css?v=2.1.1" />
   </head>
 
   <body>
@@ -62,7 +62,7 @@
               </button>
           
               <nav class="site-header__nav" id="site-header-nav" aria-label="Hauptnavigation">
-                <a class="site-header__link" href="/" data-nav>Home</a>
+                <a class="site-header__link" href="/" data-nav>Grundstücks-Check</a>
           
                 <div class="site-header__tools">
                   <button
@@ -77,14 +77,14 @@
                   </button>
           
                   <div class="site-header__tools-panel" id="site-header-tools-panel" aria-label="Tools Navigation">
+                    <a class="site-header__tools-item" href="/" data-nav>
+                      <span class="site-header__tools-title">Grundstücks-Check</span>
+                      <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
+                    </a>
+          
                     <a class="site-header__tools-item" href="/mieten-oder-kaufen-rechner.html" data-nav>
                       <span class="site-header__tools-title">Mieten oder Kaufen</span>
                       <span class="site-header__tools-sub">Finanzielle Einordnung in wenigen Klicks</span>
-                    </a>
-          
-                    <a class="site-header__tools-item" href="/" data-nav>
-                      <span class="site-header__tools-title">Wohnen oder Bauen erlaubt?</span>
-                      <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
                     </a>
                   </div>
                 </div>
@@ -177,7 +177,7 @@
 
     <footer class="container page-footer">
       <nav aria-label="Navigation im Footer">
-        <a href="/">Tool</a>
+        <a href="/">Grundstücks-Check</a>
         <a href="impressum.html" aria-current="page">Impressum</a>
         <a href="datenschutz.html">Datenschutz</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:description" content="Prüfe in 2 Minuten, ob du dein Wohn- oder Bauvorhaben auf dem Grundstück sinnvoll weiterverfolgen kannst – mit Ampel, Score, Gründen und den wichtigsten nächsten Schritten." />
   <meta name="twitter:image" content="https://grundstueckcheck.de/assets/og/grundstueckcheck-tool.jpeg" />
 
-    <link rel="stylesheet" href="styles.css?v=2.1.1" />
+    <link rel="stylesheet" href="/styles.css?v=2.1.1" />
     <link rel="stylesheet" href="tool.css?v=2.3.5" />
     <script type="application/ld+json">
   {
@@ -50,10 +50,10 @@
 },
       {
         "@type": "Question",
-        "name": "Für wen ist der Grundstücks-Check sinnvoll?",
+        "name": "Wann ist der Grundstücks-Check für mich sinnvoll?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Das Tool ist vor allem für Menschen sinnvoll, die vor Kauf, Planung oder Bauvoranfrage eine erste Einordnung wollen. Es hilft dir, typische Risiken früher zu erkennen und den nächsten sinnvollen Schritt besser einzuordnen."
+          "text": "Der Grundstücks-Check ist für dich vor allem sinnvoll, wenn du vor dem Kauf, der Planung oder vor einer Bauvoranfrage eine erste Einschätzung benötigst und wissen möchtest, welche wichtigen Punkte du zuerst klären solltest. So erkennst du typische Risiken frühzeitig und kannst den nächsten sinnvollen Schritt besser einordnen."
         }
       },
       {
@@ -158,7 +158,7 @@
             </button>
         
             <nav class="site-header__nav" id="site-header-nav" aria-label="Hauptnavigation">
-              <a class="site-header__link" href="/" data-nav>Home</a>
+              <a class="site-header__link" href="/" data-nav>Grundstücks-Check</a>
         
               <div class="site-header__tools">
                 <button
@@ -173,14 +173,14 @@
                 </button>
         
                 <div class="site-header__tools-panel" id="site-header-tools-panel" aria-label="Tools Navigation">
+                  <a class="site-header__tools-item" href="/" data-nav>
+                    <span class="site-header__tools-title">Grundstücks-Check</span>
+                    <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
+                  </a>
+        
                   <a class="site-header__tools-item" href="/mieten-oder-kaufen-rechner.html" data-nav>
                     <span class="site-header__tools-title">Mieten oder Kaufen</span>
                     <span class="site-header__tools-sub">Finanzielle Einordnung in wenigen Klicks</span>
-                  </a>
-        
-                  <a class="site-header__tools-item" href="/" data-nav>
-                    <span class="site-header__tools-title">Wohnen oder Bauen erlaubt?</span>
-                    <span class="site-header__tools-sub">Schneller Check für Ihr Grundstück</span>
                   </a>
                 </div>
               </div>
@@ -621,7 +621,7 @@
     <details>
       <summary>Wann ist der Grundstücks-Check für mich sinnvoll?</summary>
       <p>
-        Dar Gründtückscheck ist für dich vorallem sinnvoll, wenn du vor dem Kauf, der Planung oder vor einer Bauvoranfrage eine erste Einschätzung benötigst und wissen möchtest, welche wichtigen Punkte du zuerst klären sollest. So erkennst du typische Risiken frühzeitig und kannst den nächsten sinnvollen Schritt besser einordnen.
+        Der Grundstücks-Check ist für dich vor allem sinnvoll, wenn du vor dem Kauf, der Planung oder vor einer Bauvoranfrage eine erste Einschätzung benötigst und wissen möchtest, welche wichtigen Punkte du zuerst klären solltest. So erkennst du typische Risiken frühzeitig und kannst den nächsten sinnvollen Schritt besser einordnen.
       </p>
     </details>
 


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions in browsers that restrict `localStorage`/`sessionStorage` access and make consent/analytics handling more robust.
- Avoid sending duplicate `tool_completed` analytics events and ensure analytics only load when consent is granted.
- Refresh header labels, tools navigation, stylesheet paths and fix small copy issues in FAQs and metadata.

### Description
- Introduced safe storage helpers (`getStorage`, `safeGetStorageItem`, `safeSetStorageItem`, `safeRemoveStorageItem`) in `app.js` and `consent.js` and replaced direct `window.localStorage`/`window.sessionStorage` access with these wrappers to avoid exceptions.
- Added an in-memory flag `toolCompletedSentInMemory` and changed logic around `tool_completed` event emission to prevent duplicate sends while still persisting a session marker via safe session storage calls.
- Updated consent logic to use the safe storage functions for `getConsent`, `setConsent`, and version checks, and adjusted the consent banner ARIA role from `dialog`/`aria-modal` to `region`.
- Updated frontend files to use absolute stylesheet paths with a bumped version (`/styles.css?v=2.1.1`), changed various header/footer labels from "Home/Tool" to "Grundstücks-Check", added a Tools-panel entry for the main tool, and fixed several minor text and FAQ wording errors.

### Testing
- Executed the tool's internal `runSelfTests()` which validated baseline evaluation scenarios and completed successfully.
- Ran an automated consent/analytics flow check that simulated granting/denying consent and verified `loadGa()` and banner removal ran without throwing exceptions.
- Performed an automated session test that simulated repeated result renders and confirmed the `tool_completed` event is emitted only once per session (in-memory + session marker), and the session marker is set/removed via the safe storage wrappers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af214109c83238262419fff53602a)